### PR TITLE
Adding text module with markdown serialization and ref support

### DIFF
--- a/common/changes/@anticrm/text/text-module_2021-06-21-09-43.json
+++ b/common/changes/@anticrm/text/text-module_2021-06-21-09-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/text",
+      "comment": "Text module support",
+      "type": "none"
+    }
+  ],
+  "packageName": "@anticrm/text",
+  "email": "haiodo@gmail.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -35,6 +35,7 @@ specifiers:
   '@rush-temp/task-assets': file:./projects/task-assets.tgz
   '@rush-temp/task-impl': file:./projects/task-impl.tgz
   '@rush-temp/tests-server': file:./projects/tests-server.tgz
+  '@rush-temp/text': file:./projects/text.tgz
   '@rush-temp/theme': file:./projects/theme.tgz
   '@rush-temp/ui': file:./projects/ui.tgz
   '@rush-temp/workbench': file:./projects/workbench.tgz
@@ -42,6 +43,7 @@ specifiers:
   '@types/jest': ^26.0.23
   '@types/jwt-simple': ^0.5.33
   '@types/lodash': ^4.14.168
+  '@types/markdown-it': ^12.0.2
   '@types/mongodb': ^3.6.18
   '@types/node': ^14.14.40
   '@types/toposort': ~2.0.3
@@ -66,6 +68,7 @@ specifiers:
   jest: ^26.6.3
   jwt-simple: ^0.5.6
   lodash: ^4.17.21
+  markdown-it: ^12.0.6
   mini-css-extract-plugin: ^1.4.1
   mongodb: ^3.6.9
   postcss: ~8.3.4
@@ -129,6 +132,7 @@ dependencies:
   '@rush-temp/task-assets': file:projects/task-assets.tgz_a1ef5cd65bd5afee7099301696a9e3c1
   '@rush-temp/task-impl': file:projects/task-impl.tgz_a1ef5cd65bd5afee7099301696a9e3c1
   '@rush-temp/tests-server': file:projects/tests-server.tgz_ts-node@10.0.0
+  '@rush-temp/text': file:projects/text.tgz_ts-node@10.0.0
   '@rush-temp/theme': file:projects/theme.tgz_29b5792c516c436974ca1fcf79948eb4
   '@rush-temp/ui': file:projects/ui.tgz_dea33292b11ce5d7cfaa07c95df0d48c
   '@rush-temp/workbench': file:projects/workbench.tgz_a1ef5cd65bd5afee7099301696a9e3c1
@@ -136,6 +140,7 @@ dependencies:
   '@types/jest': 26.0.23
   '@types/jwt-simple': 0.5.33
   '@types/lodash': 4.14.169
+  '@types/markdown-it': 12.0.2
   '@types/mongodb': 3.6.18
   '@types/node': 14.17.0
   '@types/toposort': 2.0.3
@@ -160,6 +165,7 @@ dependencies:
   jest: 26.6.3_ts-node@10.0.0
   jwt-simple: 0.5.6
   lodash: 4.17.21
+  markdown-it: 12.0.6
   mini-css-extract-plugin: 1.6.0_webpack@5.37.1
   mongodb: 3.6.9
   postcss: 8.3.4
@@ -1041,6 +1047,10 @@ packages:
       '@types/node': 15.12.2
     dev: false
 
+  /@types/highlight.js/9.12.4:
+    resolution: {integrity: sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==}
+    dev: false
+
   /@types/istanbul-lib-coverage/2.0.3:
     resolution: {integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==}
     dev: false
@@ -1076,8 +1086,24 @@ packages:
     resolution: {integrity: sha1-+4Ocq+gUN5VPfQzQF2CtgJbsUm4=}
     dev: false
 
+  /@types/linkify-it/3.0.1:
+    resolution: {integrity: sha512-pQv3Sygwxxh6jYQzXaiyWDAHevJqWtqDUv6t11Sa9CPGiXny66II7Pl6PR8QO5OVysD6HYOkHMeBgIjLnk9SkQ==}
+    dev: false
+
   /@types/lodash/4.14.169:
     resolution: {integrity: sha512-DvmZHoHTFJ8zhVYwCLWbQ7uAbYQEk52Ev2/ZiQ7Y7gQGeV9pjBqjnQpECMHfKS1rCYAhMI7LHVxwyZLZinJgdw==}
+    dev: false
+
+  /@types/markdown-it/12.0.2:
+    resolution: {integrity: sha512-p4DIfLMmGN0iLSbMxknDXeSm8W2ZRqQeN/1EAwVxVqJietzgp3WeP1UQjCKWDXWBcEbUa1ECx8YAfdpQdDQmZQ==}
+    dependencies:
+      '@types/highlight.js': 9.12.4
+      '@types/linkify-it': 3.0.1
+      '@types/mdurl': 1.0.2
+    dev: false
+
+  /@types/mdurl/1.0.2:
+    resolution: {integrity: sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==}
     dev: false
 
   /@types/minimatch/3.0.4:
@@ -1666,6 +1692,10 @@ packages:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
     dependencies:
       sprintf-js: 1.0.3
+    dev: false
+
+  /argparse/2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: false
 
   /arr-diff/4.0.0:
@@ -2825,6 +2855,10 @@ packages:
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.1
+    dev: false
+
+  /entities/2.1.0:
+    resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
     dev: false
 
   /entities/2.2.0:
@@ -5292,6 +5326,12 @@ packages:
     resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
     dev: false
 
+  /linkify-it/3.0.2:
+    resolution: {integrity: sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==}
+    dependencies:
+      uc.micro: 1.0.6
+    dev: false
+
   /load-json-file/1.1.0:
     resolution: {integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=}
     engines: {node: '>=0.10.0'}
@@ -5455,8 +5495,23 @@ packages:
       object-visit: 1.0.1
     dev: false
 
+  /markdown-it/12.0.6:
+    resolution: {integrity: sha512-qv3sVLl4lMT96LLtR7xeRJX11OUFjsaD5oVat2/SNBIb21bJXwal2+SklcRbTwGwqWpWH/HRtYavOoJE+seL8w==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 2.1.0
+      linkify-it: 3.0.2
+      mdurl: 1.0.1
+      uc.micro: 1.0.6
+    dev: false
+
   /mdn-data/2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
+    dev: false
+
+  /mdurl/1.0.1:
+    resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
     dev: false
 
   /media-typer/0.3.0:
@@ -7992,6 +8047,10 @@ packages:
     hasBin: true
     dev: false
 
+  /uc.micro/1.0.6:
+    resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+    dev: false
+
   /unbox-primitive/1.0.1:
     resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==}
     dependencies:
@@ -9381,6 +9440,39 @@ packages:
       - mongodb-client-encryption
       - mongodb-extjson
       - snappy
+      - supports-color
+      - ts-node
+      - utf-8-validate
+    dev: false
+
+  file:projects/text.tgz_ts-node@10.0.0:
+    resolution: {integrity: sha512-q0WEblqDKwSxIQQIyYD3QyDNZoV2OfGHJqRkVYnpAnjN+OND53YGJmqYV/Fl+SxJhYGgAy3Ot7x2VqGmSbD/ug==, tarball: file:projects/text.tgz}
+    id: file:projects/text.tgz
+    name: '@rush-temp/text'
+    version: 0.0.0
+    dependencies:
+      '@jest/globals': 27.0.3
+      '@microsoft/api-extractor': 7.15.1
+      '@types/jest': 26.0.23
+      '@types/markdown-it': 12.0.2
+      '@types/node': 14.17.0
+      '@typescript-eslint/eslint-plugin': 4.23.0_c719f97a60c87a6d25fa50062da69697
+      '@typescript-eslint/parser': 4.23.0_eslint@7.28.0+typescript@4.3.2
+      eslint: 7.28.0
+      eslint-config-standard: 16.0.3_ed9009294b90f85ab7221aa5194e0642
+      eslint-config-standard-with-typescript: 20.0.0_6d17f20753d7b00dbc3a97016e3b0afb
+      eslint-plugin-import: 2.23.1_eslint@7.28.0
+      eslint-plugin-node: 11.1.0_eslint@7.28.0
+      eslint-plugin-promise: 5.1.0_eslint@7.28.0
+      eslint-plugin-standard: 5.0.0_eslint@7.28.0
+      jest: 26.6.3_ts-node@10.0.0
+      markdown-it: 12.0.6
+      prettier: 2.3.1
+      ts-jest: 26.5.6_jest@26.6.3+typescript@4.3.2
+      typescript: 4.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
       - ts-node
       - utf-8-validate

--- a/packages/text/.eslintrc.js
+++ b/packages/text/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es6: true,
+    node: true
+  },
+  extends: [
+    'standard-with-typescript'
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly'
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    project: [
+      '**/tsconfig.json'
+    ]
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  rules: {
+    '@typescript-eslint/array-type': 'off',
+    'no-void': 'off'
+  }
+}

--- a/packages/text/api-extractor.json
+++ b/packages/text/api-extractor.json
@@ -1,0 +1,17 @@
+/**
+ * Config file for API Extractor.  For more info, please visit: https://api-extractor.com
+ */
+ {
+  /**
+   * Optionally specifies another JSON config file that this file extends from.  This provides a way for
+   * standard settings to be shared across multiple projects.
+   *
+   * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
+   * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
+   * resolved using NodeJS require().
+   *
+   * SUPPORTED TOKENS: none
+   * DEFAULT VALUE: ""
+   */
+  "extends": "../../api-extractor-base.json"
+}

--- a/packages/text/jest.config.js
+++ b/packages/text/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  preset: 'ts-jest',
+  roots: [
+    '<rootDir>/src'
+  ],
+  testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
+  coverageReporters: ['text', ['lcov', { projectRoot: '../../' }]]  
+}

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@anticrm/text",
+  "version": "0.4.0",
+  "main": "lib/index.js",
+  "author": "Anticrm Platform Contributors",
+  "license": "EPL-2.0",
+  "scripts": {
+    "build": "tsc",
+    "build:docs": "api-extractor run --local",
+    "test": "jest",
+    "lint": "eslint src",
+    "lint:fix": "eslint --fix src",
+    "format": "prettier --write 'src/**/*.{ts*,js*,yml}' && eslint --fix src"
+  },
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.13.4",
+    "@types/jest": "^26.0.23",
+    "jest": "^26.6.3",
+    "prettier": "^2.2.1",
+    "ts-jest": "^26.5.6",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
+    "eslint": "^7.25.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-config-standard-with-typescript": "^20.0.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-standard": "^5.0.0",
+    "typescript": "^4.2.4",
+    "@jest/globals": "^27.0.3",
+    "@types/node": "^14.14.40",
+    "@types/markdown-it": "^12.0.2"
+  },
+  "dependencies": {
+    "markdown-it": "^12.0.6"
+  }
+}

--- a/packages/text/src/__tests__/textmodel.test.ts
+++ b/packages/text/src/__tests__/textmodel.test.ts
@@ -1,0 +1,228 @@
+//
+// Copyright © 2020 Anticrm Platform Contributors.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/* eslint-env jest */
+import { MessageNode, MessageNodeType, parseMessageMarkdown, serializeMessage } from '..'
+import { MessageMarkType } from '../model'
+
+describe('server', () => {
+  it('Check reference output', () => {
+    const t1 =
+      '{"content":[{"content":[{"text":"Hello ","type":"text"},{"marks":[{"attrs":{"class":"class:chunter.Page","id":"5f8043dc1b592de172c26181"},"type":"reference"}],"text":"[[Page1]]","type":"text"},{"text":" and ","type":"text"},{"marks":[{"attrs":{"class":"Page","id":null},"type":"reference"}],"text":"[[Page3]]","type":"text"}],"type":"paragraph"}],"type":"doc"}'
+    const msg = serializeMessage(JSON.parse(t1) as MessageNode)
+
+    expect(msg).toEqual('Hello [Page1](ref://chunter.Page#5f8043dc1b592de172c26181) and [Page3](ref://Page#)')
+  })
+  it('check list with bold and italic', () => {
+    const msg = serializeMessage(
+      JSON.parse(
+        '{"content": [{"content": [{"content": [{"content": [{"text": "test1 ", "type": "text"}, {"text": "Italic", "marks": [{"type": "em"}], "type": "text"}], "type": "paragraph"}], "type": "list_item"}, {"content": [{"content": [{"text": "test2 ", "type": "text"}, {"text": "BOLD", "marks": [{"type": "strong"}], "type": "text"}], "type": "paragraph"}], "type": "list_item"}], "type": "bullet_list"}], "type": "doc"}'
+      ) as MessageNode
+    )
+
+    expect(msg).toEqual('* test1 *Italic*\n\n* test2 **BOLD**')
+  })
+
+  // Test parser
+
+  it('Check parsing', () => {
+    const t1 = 'Hello [Page1](ref://chunter.Page#5f8043dc1b592de172c26181) and [Page3](ref://Page#)'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check parsing header', () => {
+    const t1 = '# This is header'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check parsing bullets', () => {
+    const t1 = '* Section A\n  Some text\n\n* Section B\n  Some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check parsing bullets-2', () => {
+    const t1 = '* Section A\n* Some section2'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual('* Section A\n\n* Some section2')
+  })
+
+  it('Check ordered list', () => {
+    const t1 = '1. Section A\n   Some text\n\n2. Section B\n   Some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.ordered_list)
+    expect(msg.content?.[0].content?.[0].type).toEqual(MessageNodeType.list_item)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check styles', () => {
+    const t1 = '**BOLD _ITALIC_ BOLD**'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual('**BOLD *ITALIC* BOLD**')
+  })
+
+  it('Check styles-2', () => {
+    const t1 = '**BOLD *ITALIC* BOLD**'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check styles-3', () => {
+    const t1 = 'Some *EM **MORE EM***'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.paragraph)
+    expect(msg.content?.[0].content?.length).toEqual(4)
+    expect(msg.content?.[0].content?.[2]?.marks?.length).toEqual(2)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check images', () => {
+    const t1 = 'Some text\nsome text ![This is Alt](http://url/a.png "This is title") Some text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].content?.[1].type).toEqual(MessageNodeType.image)
+    expect(msg.content?.[0].content?.[1].attrs?.src).toEqual('http://url/a.png')
+    expect(msg.content?.[0].content?.[1].attrs?.title).toEqual('This is title')
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check block quite', () => {
+    const t1 = '> Some quoted text\nand some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.blockquote)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual('> Some quoted text\n> and some more text')
+  })
+
+  it('Check block quite-2', () => {
+    const t1 = '> Some quoted text\n> and some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.blockquote)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check block quite-3', () => {
+    const t1 = '> Some quoted text\n\nand some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.blockquote)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check code block', () => {
+    const t1 = '```\n# code block\nprint \'3 backticks or\'\nprint \'indent 4 spaces\'\n```'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.code_block)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check code block language', () => {
+    const t1 = '```typescript\n# code block\nprint \'3 backticks or\'\nprint \'indent 4 spaces\'\n```'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].type).toEqual(MessageNodeType.code_block)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check link', () => {
+    const t1 = 'Some text [Link Alt](http://a.com) some more text'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check link bold', () => {
+    const t1 = '**[link](foo) is bold**"'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].content?.[1].marks?.[0]?.type).toEqual(MessageMarkType.strong)
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+
+  it('Check overlapping inline marks', () => {
+    const t1 = 'This is **strong *emphasized text with `code` in* it**'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].content?.length).toEqual(7)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual(t1)
+  })
+  it('Check emph url', () => {
+    const t1 = 'Link to *<https://hardware.it>*'
+    const msg = parseMessageMarkdown(t1)
+    expect(msg.type).toEqual(MessageNodeType.doc)
+    expect(msg.content?.[0].content?.length).toEqual(2)
+
+    const md = serializeMessage(msg)
+
+    expect(md).toEqual('Link to *<https://hardware.it](https://hardware.it)*')
+  })
+})

--- a/packages/text/src/index.ts
+++ b/packages/text/src/index.ts
@@ -1,0 +1,35 @@
+//
+// Copyright © 2020, 2021 Anticrm Platform Contributors.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import { MessageNode } from './model'
+import { MarkdownParser } from './parser'
+import { MarkdownState } from './serializer'
+
+export * from './model'
+
+export function parseMessage (message: string): MessageNode {
+  return parseMessageMarkdown(message)
+}
+
+export function parseMessageMarkdown (message: string): MessageNode {
+  const parser = new MarkdownParser()
+  return parser.parse(message ?? '')
+}
+
+export function serializeMessage (node: MessageNode): string {
+  const state = new MarkdownState()
+  state.renderContent(node)
+  return state.out
+}

--- a/packages/text/src/marks.ts
+++ b/packages/text/src/marks.ts
@@ -1,0 +1,60 @@
+import { MessageMark, MessageMarkType, MessageNode } from './model'
+
+export function traverseMarks (node: MessageNode, f: (el: MessageMark) => void): void {
+  node.marks?.forEach(f)
+}
+
+export function markAttrs (mark: MessageMark): { [key: string]: string } {
+  return mark.attrs ?? []
+}
+
+export function isInSet (mark: MessageMark, marks: MessageMark[]): boolean {
+  return marks.find((m) => markEq(mark, m)) !== undefined
+}
+
+export function addToSet (mark: MessageMark, marks: MessageMark[]): MessageMark[] {
+  const m = marks.find((m) => markEq(mark, m))
+  if (m !== undefined) {
+    // We already have mark
+    return marks
+  }
+  return [...marks, mark]
+}
+
+export function removeFromSet (markType: MessageMarkType, marks: MessageMark[]): MessageMark[] {
+  return marks.filter((m) => m.type !== markType)
+}
+
+export function sameSet (a: MessageMark[] | undefined, b: MessageMark[] | undefined): boolean {
+  if (a === b) return true
+  if (a === undefined) return false
+  if (b === undefined) return false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (!markEq(a[i], b[i])) {
+      return false
+    }
+  }
+  return true
+}
+
+export function markEq (first: MessageMark, other: MessageMark): boolean {
+  return first === other || (first.type === other.type && compareDeep(first.attrs, other.attrs))
+}
+
+function compareDeep (a: any, b: any): boolean {
+  if (a === b) return true
+  if (!(a !== undefined && typeof a === 'object') || !(b !== undefined && typeof b === 'object')) return false
+  const isarray = Array.isArray(a)
+  if (Array.isArray(b) !== isarray) return false
+  if (isarray) {
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!compareDeep(a[i], b[i])) return false
+    }
+  } else {
+    for (const p in a) if (!(p in b) || !compareDeep(a[p], b[p])) return false
+    for (const p in b) if (!(p in a)) return false
+  }
+  return true
+}

--- a/packages/text/src/model.ts
+++ b/packages/text/src/model.ts
@@ -1,0 +1,51 @@
+export enum MessageNodeType {
+  doc = 'doc',
+  paragraph = 'paragraph',
+  blockquote = 'blockquote',
+  horizontal_rule = 'horizontal_rule',
+  heading = 'heading',
+  code_block = 'code_block',
+  text = 'text',
+  image = 'image',
+  hard_break = 'hard_break',
+  ordered_list = 'ordered_list',
+  bullet_list = 'bullet_list',
+  list_item = 'list_item'
+}
+
+export enum MessageMarkType {
+  link = 'link',
+  em = 'em',
+  strong = 'strong',
+  code = 'code',
+  reference = 'reference'
+}
+
+export interface MessageMark {
+  type: MessageMarkType
+  attrs: { [key: string]: any } // A map of attributes
+}
+
+export interface MessageNode {
+  type: MessageNodeType
+  content?: MessageNode[] // A list of child nodes
+  marks?: MessageMark[]
+  attrs?: { [key: string]: string }
+  text?: string
+}
+
+export function newMessageDocument (): MessageNode {
+  return {
+    type: MessageNodeType.doc,
+    content: [{ type: MessageNodeType.paragraph }]
+  }
+}
+
+export interface LinkMark extends MessageMark {
+  href: string
+  title: string
+}
+
+export interface ReferenceMark extends MessageMark {
+  attrs: { id: string, class: string }
+}

--- a/packages/text/src/node.ts
+++ b/packages/text/src/node.ts
@@ -1,0 +1,14 @@
+import { MessageNode } from './model'
+
+export function traverseMessage (node: MessageNode, f: (el: MessageNode) => void): void {
+  f(node)
+  node.content?.forEach((c) => traverseMessage(c, f))
+}
+
+export function messageContent (node: MessageNode): MessageNode[] {
+  return node?.content ?? []
+}
+
+export function nodeAttrs (node: MessageNode): { [key: string]: string } {
+  return node.attrs ?? {}
+}

--- a/packages/text/src/parser.ts
+++ b/packages/text/src/parser.ts
@@ -1,0 +1,329 @@
+import MarkdownIt = require('markdown-it')
+import Token = require('markdown-it/lib/token')
+
+import { MessageNode, MessageNodeType, MessageMarkType, MessageMark } from './model'
+import { addToSet, removeFromSet, sameSet } from './marks'
+
+interface ParsingRule {
+  block?: MessageNodeType
+  getAttrs?: (tok: Token) => { [key: string]: string }
+  noCloseToken?: boolean
+  node?: MessageNodeType
+  mark?: MessageMarkType
+}
+
+// ****************************************************************
+// Mark down parser
+// ****************************************************************
+function isText (a: MessageNode): boolean {
+  return a.type === MessageNodeType.text
+}
+function maybeMerge (a: MessageNode, b: MessageNode): MessageNode | undefined {
+  if (isText(a) && isText(b) && sameSet(a.marks, b.marks)) {
+    return { ...a, text: (a.text ?? '') + (b.text ?? '') }
+  }
+  return undefined
+}
+
+interface StateElement {
+  type: MessageNodeType
+  content: MessageNode[]
+  attrs: { [key: string]: string }
+}
+
+// Object used to track the context of a running parse.
+class MarkdownParseState {
+  stack: StateElement[]
+  marks: MessageMark[]
+  tokenHandlers: Record<string, (state: MarkdownParseState, tok: Token) => void>
+
+  constructor (tokenHandlers: Record<string, (state: MarkdownParseState, tok: Token) => void>) {
+    this.stack = [{ type: MessageNodeType.doc, attrs: {}, content: [] }]
+    this.marks = []
+    this.tokenHandlers = tokenHandlers
+  }
+
+  top (): StateElement | undefined {
+    return this.stack[this.stack.length - 1]
+  }
+
+  push (elt: MessageNode): void {
+    if (this.stack.length > 0) {
+      const tt = this.top()
+      tt?.content.push(elt)
+    }
+  }
+
+  // : (MessageMark[])
+  // Convert linsk to references in case of ref:// schema.
+  convertReferences (marks: MessageMark[]): MessageMark[] {
+    const result: MessageMark[] = []
+    for (let i = 0; i < marks.length; i++) {
+      const m = marks[i]
+      if (m.type !== MessageMarkType.link) {
+        result.push(m)
+        continue
+      }
+      if (m.attrs.href !== undefined) {
+        const ref = m.attrs.href as string
+        const refPrefix = 'ref://'
+        const hashPos = ref.indexOf('#')
+        if (ref.startsWith(refPrefix) && hashPos !== -1) {
+          // Convert any url with ref to reference mark
+          result.push({
+            type: MessageMarkType.reference,
+            attrs: {
+              id: ref.substring(hashPos + 1),
+              class: 'class:' + ref.substring(refPrefix.length, hashPos)
+            }
+          })
+        } else {
+          // Not our ref case, just add link
+          result.push(m)
+        }
+      }
+    }
+    return result
+  }
+
+  // : (string)
+  // Adds the given text to the current position in the document,
+  // using the current marks as styling.
+  addText (text: string | undefined): void {
+    if (text === undefined) return
+    const top = this.top()
+    if (top === undefined) {
+      return
+    }
+    const nodes = top.content
+    const last = nodes[nodes.length - 1]
+    const node: MessageNode = {
+      type: MessageNodeType.text,
+      text: text
+    }
+    if (this.marks.length > 0) {
+      node.marks = this.convertReferences(this.marks)
+    }
+
+    let merged: MessageNode | undefined
+    if (last !== undefined && (merged = maybeMerge(last, node)) !== undefined) {
+      nodes[nodes.length - 1] = merged
+    } else {
+      nodes.push(node)
+    }
+  }
+
+  // : (Mark)
+  // Adds the given mark to the set of active marks.
+  openMark (mark: MessageMark): void {
+    this.marks = addToSet(mark, this.marks)
+  }
+
+  // : (Mark)
+  // Removes the given mark from the set of active marks.
+  closeMark (mark: MessageMarkType): void {
+    this.marks = removeFromSet(mark, this.marks)
+  }
+
+  parseTokens (toks: Token[] | null): void {
+    if (toks === null) {
+      return
+    }
+    for (const tok of toks) {
+      const handler = this.tokenHandlers[tok.type]
+      if (handler === undefined) {
+        throw new Error(`Token type '${String(tok.type)} not supported by Markdown parser`)
+      }
+      handler(this, tok)
+    }
+  }
+
+  // : (NodeType, ?Object, ?[Node]) → ?Node
+  // Add a node at the current position.
+  addNode (type: MessageNodeType, attrs: { [key: string]: string }, content: MessageNode[] = []): MessageNode {
+    const node: MessageNode = { type: type, content: content }
+
+    if (Object.keys(attrs ?? {}).length > 0) {
+      node.attrs = attrs
+    }
+    if (this.marks.length > 0) {
+      node.marks = this.marks
+    }
+    this.push(node)
+    return node
+  }
+
+  // : (NodeType, ?Object)
+  // Wrap subsequent content in a node of the given type.
+  openNode (type: MessageNodeType, attrs: { [key: string]: string }): void {
+    this.stack.push({ type: type, attrs, content: [] })
+  }
+
+  // : () → ?Node
+  // Close and return the node that is currently on top of the stack.
+  closeNode (): MessageNode {
+    if (this.marks.length > 0) this.marks = []
+    const info = this.stack.pop()
+    if (info !== undefined) {
+      return this.addNode(info.type, info.attrs, info.content)
+    }
+    return { type: MessageNodeType.doc }
+  }
+}
+
+function attrs (spec: ParsingRule, token: Token): { [key: string]: string } {
+  return spec.getAttrs?.(token) ?? {}
+}
+
+// Code content is represented as a single token with a `content`
+// property in Markdown-it.
+function noCloseToken (spec: ParsingRule, type: any): boolean {
+  return (spec?.noCloseToken ?? false) || type === 'code_inline' || type === 'code_block' || type === 'fence'
+}
+
+function withoutTrailingNewline (str: string): string {
+  return str[str.length - 1] === '\n' ? str.slice(0, str.length - 1) : str
+}
+
+function tokenHandlers (tokens: { [key: string]: ParsingRule }): Record<string, (state: MarkdownParseState, tok: Token) => void> {
+  const handlers: Record<string, (state: MarkdownParseState, tok: Token) => void> = {}
+
+  function addSpecBlock (spec: ParsingRule, type: string, specBlock: MessageNodeType): void {
+    if (noCloseToken(spec, type)) {
+      handlers[type] = (state: MarkdownParseState, tok: Token) => {
+        state.openNode(specBlock, attrs(spec, tok))
+        state.addText(withoutTrailingNewline(tok.content))
+        state.closeNode()
+      }
+    } else {
+      handlers[type + '_open'] = (state: MarkdownParseState, tok: Token) => state.openNode(specBlock, attrs(spec, tok))
+      handlers[type + '_close'] = (state: MarkdownParseState) => state.closeNode()
+    }
+  }
+
+  function addMarkBlock (spec: ParsingRule, type: string, specMark: MessageMarkType): void {
+    if (noCloseToken(spec, type)) {
+      handlers[type] = (state: MarkdownParseState, tok: Token) => {
+        state.openMark({ attrs: attrs(spec, tok), type: specMark })
+        state.addText(withoutTrailingNewline(tok.content))
+        state.closeMark(specMark)
+      }
+    } else {
+      handlers[type + '_open'] = (state: MarkdownParseState, tok: Token) =>
+        state.openMark({ type: specMark, attrs: attrs(spec, tok) })
+      handlers[type + '_close'] = (state: MarkdownParseState) => {
+        state.closeMark(specMark)
+      }
+    }
+  }
+
+  for (const type in tokens) {
+    const spec = tokens[type]
+    const specBlock = spec.block
+    const specNode = spec.node
+    const specMark = spec.mark
+
+    if (specBlock !== undefined) {
+      addSpecBlock(spec, type, specBlock)
+    } else if (specNode !== undefined) {
+      handlers[type] = (state: MarkdownParseState, tok: Token) => state.addNode(specNode, attrs(spec, tok))
+    } else if (specMark !== undefined) {
+      addMarkBlock(spec, type, specMark)
+    } else {
+      throw new RangeError('Unrecognized parsing spec ' + JSON.stringify(spec))
+    }
+  }
+
+  handlers.text = (state, tok) => state.addText(tok.content)
+  handlers.inline = (state, tok) => state.parseTokens(tok.children)
+  handlers.softbreak = handlers.softbreak ?? ((state: any) => state.addText('\n'))
+
+  return handlers
+}
+
+function tokAttrGet (token: Token, name: string): string | undefined {
+  const attr = token.attrGet(name)
+  if (attr === null) {
+    return undefined
+  }
+}
+
+function tokToAttrs (token: Token, ...names: string[]): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const name of names) {
+    const attr = token.attrGet(name)
+    if (attr !== null) {
+      result[name] = attr
+    }
+  }
+  return result
+}
+
+// ::- A configuration of a Markdown parser. Such a parser uses
+const tokens: { [key: string]: ParsingRule } = {
+  blockquote: { block: MessageNodeType.blockquote },
+  paragraph: { block: MessageNodeType.paragraph },
+  list_item: { block: MessageNodeType.list_item },
+  bullet_list: { block: MessageNodeType.bullet_list },
+  ordered_list: {
+    block: MessageNodeType.ordered_list,
+    getAttrs: (tok: Token) => ({ order: tokAttrGet(tok, 'start') ?? '1' })
+  },
+  heading: {
+    block: MessageNodeType.heading,
+    getAttrs: (tok: Token) => ({ level: tok.tag.slice(1) })
+  },
+  code_block: {
+    block: MessageNodeType.code_block,
+    noCloseToken: true
+  },
+  fence: {
+    block: MessageNodeType.code_block,
+    getAttrs: (tok: Token) => ({ params: tok.info ?? '' }),
+    noCloseToken: true
+  },
+  hr: { node: MessageNodeType.horizontal_rule },
+  image: {
+    node: MessageNodeType.image,
+    getAttrs: (tok: Token) => {
+      const result = tokToAttrs(tok, 'src', 'title', 'alt')
+      if (tok.content !== '' && (result.alt === '' || result.alt == null)) {
+        result.alt = tok.content
+      }
+      return result
+    }
+  },
+  hardbreak: { node: MessageNodeType.hard_break },
+
+  em: { mark: MessageMarkType.em },
+  strong: { mark: MessageMarkType.strong },
+  link: {
+    mark: MessageMarkType.link,
+    getAttrs: (tok: Token) => tokToAttrs(tok, 'href', 'title')
+  },
+  code_inline: {
+    mark: MessageMarkType.code,
+    noCloseToken: true
+  }
+}
+
+export class MarkdownParser {
+  tokenizer: MarkdownIt
+  tokenHandlers: Record<string, (state: MarkdownParseState, tok: Token) => void>
+
+  constructor () {
+    this.tokenizer = MarkdownIt('commonmark', { html: false })
+    this.tokenHandlers = tokenHandlers(tokens)
+  }
+
+  parse (text: string): MessageNode {
+    const state = new MarkdownParseState(this.tokenHandlers)
+    let doc: MessageNode
+
+    state.parseTokens(this.tokenizer.parse(text, {}))
+    do {
+      doc = state.closeNode()
+    } while (state.stack.length > 0)
+    return doc
+  }
+}

--- a/packages/text/src/serializer.ts
+++ b/packages/text/src/serializer.ts
@@ -1,0 +1,508 @@
+import { isInSet, markAttrs, markEq, traverseMarks } from './marks'
+import { MessageMark, MessageMarkType, MessageNode, MessageNodeType } from './model'
+import { messageContent, nodeAttrs } from './node'
+
+type FirstDelim = (i: number) => string
+interface IState {
+  wrapBlock: (delim: string, firstDelim: string | null, node: MessageNode, f: () => void) => void
+  flushClose: (size: number) => void
+  atBlank: () => void
+  ensureNewLine: () => void
+  write: (content: string) => void
+  closeBlock: (node: any) => void
+  text: (text: string, escape?: boolean) => void
+  render: (node: MessageNode, parent: MessageNode, index: number) => void
+  renderContent: (parent: MessageNode) => void
+  renderInline: (parent: MessageNode) => void
+  renderList: (node: MessageNode, delim: string, firstDelim: FirstDelim) => void
+  esc: (str: string, startOfLine?: boolean) => string
+  quote: (str: string) => string
+  repeat: (str: string, n: number) => string
+  markString: (mark: MessageMark, open: boolean, parent: MessageNode, index: number) => string
+  getEnclosingWhitespace: (text: string) => { leading: string, trailing: string }
+}
+
+type NodeProcessor = (state: IState, node: MessageNode, parent: MessageNode, index: number) => void
+
+// *************************************************************
+
+function backticksFor (node: MessageNode, side: any): string {
+  const ticks = /`+/g
+  let m: RegExpExecArray | null
+  let len = 0
+  if (node.type === MessageNodeType.text) {
+    while ((m = ticks.exec(node.text ?? '')) !== null) len = Math.max(len, m[0].length)
+  }
+  let result = len > 0 && side > 0 ? ' `' : '`'
+  for (let i = 0; i < len; i++) {
+    result += '`'
+  }
+  if (len > 0 && side < 0) {
+    result += ' '
+  }
+  return result
+}
+
+function isPlainURL (link: MessageMark, parent: MessageNode, index: number, side: number): boolean {
+  const attrs = markAttrs(link)
+  if (attrs.title !== undefined || !/^\w+:/.test(attrs.href)) return false
+
+  const parentContent = messageContent(parent)
+  const content = parentContent[index + (side < 0 ? -1 : 0)]
+  const marks = [...(content?.marks ?? [])]
+
+  if (content?.type !== MessageNodeType.text || content?.text !== attrs.href || marks[marks.length - 1] !== link) {
+    return false
+  }
+  if (index === (side < 0 ? 1 : parentContent.length - 1)) return true
+  const next = parentContent[index + (side < 0 ? -2 : 1)]
+  return !isInSet(link, [...(next.marks ?? [])])
+}
+
+// *************************************************************
+
+export const storeNodes: { [key: string]: NodeProcessor } = {
+  blockquote: (state, node) => {
+    state.wrapBlock('> ', null, node, () => state.renderContent(node))
+  },
+  code_block: (state, node) => {
+    state.write('```' + (nodeAttrs(node).params ?? '') + '\n')
+    // TODO: Check for node.textContent
+    state.renderInline(node)
+    // state.text(node.text ?? '', false)
+    state.ensureNewLine()
+    state.write('```')
+    state.closeBlock(node)
+  },
+  heading: (state, node) => {
+    const attrs = nodeAttrs(node)
+    state.write(state.repeat('#', attrs.level !== undefined ? Number(attrs.level) : 1) + ' ')
+    state.renderInline(node)
+    state.closeBlock(node)
+  },
+  horizontal_rule: (state, node) => {
+    state.write(nodeAttrs(node).markup ?? '---')
+    state.closeBlock(node)
+  },
+  bullet_list: (state, node) => {
+    state.renderList(node, '  ', () => (nodeAttrs(node).bullet ?? '*') + ' ')
+  },
+  ordered_list: (state, node) => {
+    let start = 1
+    if (nodeAttrs(node).order !== undefined) {
+      start = Number(nodeAttrs(node).order)
+    }
+    const maxW = String(start + messageContent(node).length - 1).length
+    const space = state.repeat(' ', maxW + 2)
+    state.renderList(node, space, (i: number) => {
+      const nStr = String(start + i)
+      return state.repeat(' ', maxW - nStr.length) + nStr + '. '
+    })
+  },
+  list_item: (state, node) => {
+    state.renderContent(node)
+  },
+  paragraph: (state, node) => {
+    state.renderInline(node)
+    state.closeBlock(node)
+  },
+
+  image: (state, node) => {
+    const attrs = nodeAttrs(node)
+    state.write(
+      '![' +
+        state.esc(attrs.alt ?? '') +
+        '](' +
+        state.esc(attrs.src) +
+        (attrs.title !== undefined ? ' ' + state.quote(attrs.title) : '') +
+        ')'
+    )
+  },
+  hard_break: (state, node, parent, index) => {
+    const content = messageContent(parent)
+    for (let i = index + 1; i < content.length; i++) {
+      if (content[i].type !== node.type) {
+        state.write('\\\n')
+        return
+      }
+    }
+  },
+  text: (state, node) => {
+    // Check if test has reference mark, in this case we need to remove [[]]
+    let txt = node.text ?? ''
+
+    traverseMarks(node, (m) => {
+      if (m.type === MessageMarkType.reference) {
+        if (txt.startsWith('[[') && txt.endsWith(']]')) {
+          txt = txt.substring(2, txt.length - 2)
+        }
+      }
+    })
+    state.text(txt)
+  }
+}
+
+interface MarkProcessor {
+  open: ((_state: IState, mark: MessageMark, parent: MessageNode, index: number) => string) | string
+  close: ((_state: IState, mark: MessageMark, parent: MessageNode, index: number) => string) | string
+  mixable: boolean
+  expelEnclosingWhitespace: boolean
+  escape: boolean
+}
+
+export const storeMarks: { [key: string]: MarkProcessor } = {
+  em: {
+    open: '*',
+    close: '*',
+    mixable: true,
+    expelEnclosingWhitespace: true,
+    escape: true
+  },
+  strong: {
+    open: '**',
+    close: '**',
+    mixable: true,
+    expelEnclosingWhitespace: true,
+    escape: true
+  },
+  link: {
+    open: (state, mark, parent, index) => {
+      return isPlainURL(mark, parent, index, 1) ? '<' : '['
+    },
+    close: (state, mark, parent, index) => {
+      return isPlainURL(mark, parent, index, -1)
+        ? '>'
+        : '](' +
+            state.esc(mark.attrs.href) +
+            (mark.attrs.title !== undefined ? ' ' + state.quote(mark.attrs.title) : '') +
+            ')'
+    },
+    mixable: false,
+    expelEnclosingWhitespace: false,
+    escape: true
+  },
+  reference: {
+    open: (state, mark, parent, index) => {
+      return isPlainURL(mark, parent, index, 1) ? '<' : '['
+    },
+    close: (state, mark, parent, index) => {
+      return isPlainURL(mark, parent, index, -1)
+        ? '>'
+        : '](ref://' + state.esc(mark.attrs.class).replace('class:', '') + '#' + state.esc(mark.attrs.id) + ')'
+    },
+    mixable: false,
+    expelEnclosingWhitespace: false,
+    escape: true
+  },
+  code: {
+    open: (state, mark, parent, index) => {
+      return backticksFor(messageContent(parent)[index], -1)
+    },
+    close: (state, mark, parent, index) => {
+      return backticksFor(messageContent(parent)[index - 1], 1)
+    },
+    mixable: false,
+    expelEnclosingWhitespace: false,
+    escape: false
+  }
+}
+
+export class MarkdownState implements IState {
+  nodes: { [key: string]: NodeProcessor }
+  marks: { [key: string]: MarkProcessor }
+  delim: string
+  out: string
+  closed: boolean
+  closedNode?: MessageNode
+  inTightList: boolean
+  options: any
+
+  constructor (nodes: any = storeNodes, marks: any = storeMarks, options: any = {}) {
+    this.nodes = nodes
+    this.marks = marks
+    this.delim = this.out = ''
+    this.closed = false
+    this.inTightList = false
+
+    this.options = options ?? {}
+    if (typeof this.options.tightLists === 'undefined') {
+      this.options.tightLists = false
+    }
+  }
+
+  flushClose (size: number): void {
+    if (this.closed) {
+      if (!this.atBlank()) this.out += '\n'
+      if (size == null) size = 2
+      if (size > 1) {
+        let delimMin = this.delim
+        const trim = /\s+$/.exec(delimMin)
+        if (trim !== null) delimMin = delimMin.slice(0, delimMin.length - trim[0].length)
+        for (let i = 1; i < size; i++) this.out += delimMin + '\n'
+      }
+      this.closed = false
+    }
+  }
+
+  wrapBlock (delim: string, firstDelim: string | null, node: MessageNode, f: () => void): void {
+    const old = this.delim
+    this.write(firstDelim ?? delim)
+    this.delim += delim
+    f()
+    this.delim = old
+    this.closeBlock(node)
+  }
+
+  atBlank (): boolean {
+    return /(^|\n)$/.test(this.out)
+  }
+
+  // :: ()
+  // Ensure the current content ends with a newline.
+  ensureNewLine (): void {
+    if (!this.atBlank()) this.out += '\n'
+  }
+
+  // :: (?string)
+  // Prepare the state for writing output (closing closed paragraphs,
+  // adding delimiters, and so on), and then optionally add content
+  // (unescaped) to the output.
+  write (content: string): void {
+    this.flushClose(2)
+    if (this.delim !== undefined && this.atBlank()) this.out += this.delim
+    if (content.length > 0) this.out += content
+  }
+
+  // :: (Node)
+  // Close the block for the given node.
+  closeBlock (node: MessageNode): void {
+    this.closedNode = node
+    this.closed = true
+  }
+
+  // :: (string, ?bool)
+  // Add the given text to the document. When escape is not `false`,
+  // it will be escaped.
+  text (text: string, escape = false): void {
+    const lines = text.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      const startOfLine = this.atBlank() || this.closed
+      this.write('')
+      this.out += escape ? this.esc(lines[i], startOfLine) : lines[i]
+      if (i !== lines.length - 1) this.out += '\n'
+    }
+  }
+
+  // :: (Node)
+  // Render the given node as a block.
+  render (node: MessageNode, parent: MessageNode, index: number): void {
+    if (typeof parent === 'number') throw new Error('!')
+    if (this.nodes[node.type] === undefined) {
+      throw new Error('Token type `' + node.type + '` not supported by Markdown renderer')
+    }
+    this.nodes[node.type](this, node, parent, index)
+  }
+
+  // :: (Node)
+  // Render the contents of `parent` as block nodes.
+  renderContent (parent: MessageNode): void {
+    messageContent(parent).forEach((node: MessageNode, i: number) => this.render(node, parent, i))
+  }
+
+  // :: (Node)
+  // Render the contents of `parent` as inline content.
+  renderInline (parent: MessageNode): void {
+    const active: MessageMark[] = []
+    let trailing = ''
+    const progress = (node: MessageNode | undefined, index: number): void => {
+      let marks: MessageMark[] = node?.marks ?? []
+
+      if (node !== undefined && node.type === MessageNodeType.hard_break) {
+        marks = marks.filter((m: MessageMark) => {
+          if (index + 1 === parent.content?.length) {
+            return false
+          }
+          if (parent.content !== undefined) {
+            const next = parent.content[index + 1]
+            return (
+              isInSet(m, next?.marks ?? []) &&
+              (next.type !== MessageNodeType.text || (next.text !== undefined && /\S/.test(next.text)))
+            )
+          } else {
+            return false
+          }
+        })
+      }
+
+      let leading = trailing
+      trailing = ''
+      // If whitespace has to be expelled from the node, adjust
+      // leading and trailing accordingly.
+      if (
+        node !== undefined &&
+        node.type === MessageNodeType.text &&
+        marks.some((mark: MessageMark) => {
+          const info = this.marks[mark.type]
+          return info?.expelEnclosingWhitespace
+        }) &&
+        node.text !== undefined
+      ) {
+        const ex = /^(\s*)(.*?)(\s*)$/m.exec(node.text)
+        if (ex !== null) {
+          const [_, lead, inner, trail] = ex // eslint-disable-line
+          leading += lead
+          trailing = trail
+          if (lead !== '' || trail !== '') {
+            node = inner !== undefined ? { ...node, text: inner } : undefined
+            if (node === undefined) marks = active
+          }
+        }
+      }
+
+      const inner: MessageMark | undefined = marks.length > 0 ? marks[marks.length - 1] : undefined
+      const noEsc = inner !== undefined && !this.marks[inner.type].escape
+      const len = marks.length - (noEsc ? 1 : 0)
+
+      // Try to reorder 'mixable' marks, such as em and strong, which
+      // in Markdown may be opened and closed in different order, so
+      // that order of the marks for the token matches the order in
+      // active.
+
+      // eslint-disable-next-line
+      outer: for (let i = 0; i < len; i++) {
+        const mark = marks[i]
+        if (!this.marks[mark.type].mixable) break
+        for (let j = 0; j < active.length; j++) {
+          const other = active[j]
+          if (!this.marks[other.type].mixable) break
+          if (markEq(mark, other)) {
+            if (i > j) {
+              marks = marks
+                .slice(0, j)
+                .concat(mark)
+                .concat(marks.slice(j, i))
+                .concat(marks.slice(i + 1, len))
+            } else if (j > i) {
+              marks = marks
+                .slice(0, i)
+                .concat(marks.slice(i + 1, j))
+                .concat(mark)
+                .concat(marks.slice(j, len))
+            }
+            continue outer // eslint-disable-line
+          }
+        }
+      }
+
+      // Find the prefix of the mark set that didn't change
+      let keep = 0
+      while (keep < Math.min(active.length, len) && markEq(marks[keep], active[keep])) {
+        ++keep
+      }
+
+      // Close the marks that need to be closed
+      while (keep < active.length) {
+        const mark = active.pop()
+        if (mark !== undefined) {
+          this.text(this.markString(mark, false, parent, index), false)
+        }
+      }
+
+      // Output any previously expelled trailing whitespace outside the marks
+      if (leading !== '') this.text(leading)
+
+      // Open the marks that need to be opened
+      if (node !== undefined) {
+        while (active.length < len) {
+          const add = marks[active.length]
+          active.push(add)
+          this.text(this.markString(add, true, parent, index), false)
+        }
+
+        // Render the node. Special case code marks, since their content
+        // may not be escaped.
+        if (inner !== undefined && noEsc && node.type === MessageNodeType.text) {
+          this.text(
+            this.markString(inner, true, parent, index) +
+              (node?.text as string) +
+              this.markString(inner, false, parent, index + 1),
+            false
+          )
+        } else {
+          this.render(node, parent, index)
+        }
+      }
+    }
+    messageContent(parent).forEach(progress)
+    progress(undefined, 0)
+  }
+
+  // :: (Node, string, (number) → string)
+  // Render a node's content as a list. `delim` should be the extra
+  // indentation added to all lines except the first in an item,
+  // `firstDelim` is a function going from an item index to a
+  // delimiter for the first line of the item.
+  renderList (node: MessageNode, delim: string, firstDelim: FirstDelim): void {
+    if (this.closed && this.closedNode?.type === node.type) {
+      this.flushClose(3)
+    } else if (this.inTightList) this.flushClose(1)
+
+    const isTight: boolean =
+      node.attrs !== undefined && (typeof node.attrs.tight !== 'undefined' ? node.attrs.tight : this.options.tightLists)
+    const prevTight = this.inTightList
+    this.inTightList = isTight
+
+    messageContent(node).forEach((child: MessageNode, i: number) => {
+      if (i > 0 && isTight) this.flushClose(1)
+      this.wrapBlock(delim, firstDelim(i), node, () => this.render(child, node, i))
+    })
+    this.inTightList = prevTight
+  }
+
+  // :: (string, ?bool) → string
+  // Escape the given string so that it can safely appear in Markdown
+  // content. If `startOfLine` is true, also escape characters that
+  // has special meaning only at the start of the line.
+  esc (str: string, startOfLine = false): string {
+    if (str == null) {
+      return ''
+    }
+    str = str.replace(/[`*\\~\[\]]/g, '\\$&') // eslint-disable-line
+    if (startOfLine) {
+      str = str.replace(/^[:#\-*+]/, '\\$&').replace(/^(\d+)\./, '$1\\.')
+    }
+    return str
+  }
+
+  quote (str: string): string {
+    const wrap = !str.includes('"') ? '""' : !str.includes("'") ? "''" : '()'
+    return wrap[0] + str + wrap[1]
+  }
+
+  // :: (string, number) → string
+  // Repeat the given string `n` times.
+  repeat (str: string, n: number): string {
+    let out = ''
+    for (let i = 0; i < n; i++) out += str
+    return out
+  }
+
+  // : (Mark, bool, string?) → string
+  // Get the markdown string for a given opening or closing mark.
+  markString (mark: MessageMark, open: boolean, parent: MessageNode, index: number): string {
+    const info = this.marks[mark.type]
+    const value = open ? info.open : info.close
+    return typeof value === 'string' ? value : value(this, mark, parent, index) ?? ''
+  }
+
+  // :: (string) → { leading: ?string, trailing: ?string }
+  // Get leading and trailing whitespace from a string. Values of
+  // leading or trailing property of the return object will be undefined
+  // if there is no match.
+  getEnclosingWhitespace (text: string): { leading: string, trailing: string } {
+    return {
+      leading: (text.match(/^(\s+)/) ?? [])[0],
+      trailing: (text.match(/(\s+)$/) ?? [])[0]
+    }
+  }
+}

--- a/packages/text/tsconfig.json
+++ b/packages/text/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": true
+  }
+}

--- a/rush.json
+++ b/rush.json
@@ -551,6 +551,11 @@
       "packageName": "@anticrm/mongo",
       "projectFolder": "server/mongo",
       "shouldPublish": true
+    },
+    {
+      "packageName": "@anticrm/text",
+      "projectFolder": "packages/text",
+      "shouldPublish": true
     }
 
     // {


### PR DESCRIPTION
Adding text module with markdown serialization and ref support.

Support parsing of markdown and build structure model with markdown-it.
Structure model is compatible with prosemirror plugin, so it could be rich edited with it.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>