### PR TITLE
Reduce packages/model complexity and reformat

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -135,7 +135,7 @@ dependencies:
   '@rush-temp/elastic': file:projects/elastic.tgz_ts-node@10.0.0
   '@rush-temp/login': file:projects/login.tgz_@typescript-eslint+parser@4.23.0
   '@rush-temp/login-impl': file:projects/login-impl.tgz_0197273999bdabbd0908f89676fc5678
-  '@rush-temp/model': file:projects/model.tgz_a1ef5cd65bd5afee7099301696a9e3c1
+  '@rush-temp/model': file:projects/model.tgz_ts-node@10.0.0
   '@rush-temp/model-all': file:projects/model-all.tgz_1cb27354e0b191fb8b28e4e6b0306c2b
   '@rush-temp/model-chunter': file:projects/model-chunter.tgz_a1ef5cd65bd5afee7099301696a9e3c1
   '@rush-temp/model-core': file:projects/model-core.tgz_1cb27354e0b191fb8b28e4e6b0306c2b
@@ -9098,7 +9098,7 @@ packages:
     version: 0.0.0
     dependencies:
       '@elastic/elasticsearch': 7.13.0
-      '@jest/globals': 27.0.3
+      '@jest/globals': 27.0.5
       '@microsoft/api-extractor': 7.15.1
       '@types/jest': 26.0.23
       '@types/node': 14.17.0
@@ -9314,8 +9314,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  file:projects/model.tgz_a1ef5cd65bd5afee7099301696a9e3c1:
-    resolution: {integrity: sha512-R8tMrEbC9A7ue9o/gosPW4kib9SSeFoaOkzjjLcUWXAV6ic+NeYf5MuMUauUWjqNEesQbpq5WbKzxq9MG51VYQ==, tarball: file:projects/model.tgz}
+  file:projects/model.tgz_ts-node@10.0.0:
+    resolution: {integrity: sha512-oYepL/glV/ikqDCjX/N0dqSgbjcrCP1QjeTFCKoWh7BYdgrWTw3xFJPgxvyzopgn9Bs27X1LOoWYUhb8xHKsrA==, tarball: file:projects/model.tgz}
     id: file:projects/model.tgz
     name: '@rush-temp/model'
     version: 0.0.0
@@ -9323,14 +9323,21 @@ packages:
       '@microsoft/api-extractor': 7.15.1
       '@types/jest': 26.0.23
       '@types/toposort': 2.0.3
+      '@typescript-eslint/eslint-plugin': 4.23.0_c719f97a60c87a6d25fa50062da69697
+      '@typescript-eslint/parser': 4.23.0_eslint@7.28.0+typescript@4.3.2
+      eslint: 7.28.0
+      eslint-config-standard: 16.0.3_ed9009294b90f85ab7221aa5194e0642
+      eslint-config-standard-with-typescript: 20.0.0_6d17f20753d7b00dbc3a97016e3b0afb
+      eslint-plugin-import: 2.23.1_eslint@7.28.0
+      eslint-plugin-node: 11.1.0_eslint@7.28.0
+      eslint-plugin-promise: 5.1.0_eslint@7.28.0
+      eslint-plugin-standard: 5.0.0_eslint@7.28.0
       jest: 26.6.3_ts-node@10.0.0
       prettier: 2.3.1
       toposort: 2.0.2
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.3.2
-      ts-standard: 10.0.0_f449690769d268be8252d4a3fecd2872
       typescript: 4.3.2
     transitivePeerDependencies:
-      - '@typescript-eslint/parser'
       - bufferutil
       - canvas
       - supports-color
@@ -9694,7 +9701,7 @@ packages:
     dev: false
 
   file:projects/server.tgz:
-    resolution: {integrity: sha512-tDDQHt1jiXg4cZ6OTbsek/cSP5eSiFCFRCWmOkVxjx4LbO1oPgKK1sHMEV01FlPYob2AEBXOXSsqIqG6pd1bIQ==, tarball: file:projects/server.tgz}
+    resolution: {integrity: sha512-BMS/fAygDmn+qvXiHKKxBZYaJ7jR9iVWT/s6pj+DuGoe1AGpLYampU76yL3bY9CKwkqSkhRlDbbY75h/irJiag==, tarball: file:projects/server.tgz}
     name: '@rush-temp/server'
     version: 0.0.0
     dependencies:

--- a/packages/model/.eslintrc.js
+++ b/packages/model/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es6: true,
+    node: true
+  },
+  extends: [
+    'standard-with-typescript'
+  ],
+  globals: {
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly'
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    project: [
+      '**/tsconfig.json'
+    ]
+  },
+  plugins: ['@typescript-eslint', 'import'],
+  rules: {
+    '@typescript-eslint/array-type': 'off',
+    'no-void': 'off'
+  }
+}

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -8,16 +8,24 @@
     "build": "tsc",
     "build:docs": "api-extractor run --local",
     "test": "jest",
-    "lint": "ts-standard src",
-    "lint:fix": "ts-standard --fix src",
-    "format": "prettier --write 'src/**/*.{ts*,js*,yml}' && ts-standard --fix src"
+    "lint": "eslint src",
+    "lint:fix": "eslint --fix src",
+    "format": "prettier --write 'src/**/*.{ts*,js*,yml}' && eslint --fix src"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.13.4",
     "@types/jest": "^26.0.23",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
-    "ts-standard": "^10.0.0",
+    "@typescript-eslint/eslint-plugin": "^4.22.0",
+    "@typescript-eslint/parser": "^4.22.0",
+    "eslint": "^7.25.0",
+    "eslint-config-standard": "^16.0.2",
+    "eslint-config-standard-with-typescript": "^20.0.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "eslint-plugin-standard": "^5.0.0",
     "typescript": "^4.2.4",
     "ts-jest": "^26.5.6",
     "@types/toposort": "~2.0.3"

--- a/packages/model/src/__tests__/dsl.test.ts
+++ b/packages/model/src/__tests__/dsl.test.ts
@@ -42,31 +42,31 @@ describe('dsl', () => {
     removeIds(txes)
     expect(txes).toEqual([
       {
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectId": "class:test.MyClass",
-        "objectClass": "class:core.Class",
-        "objectSpace": "space:core.Model",
-        "attributes": {
-          "kind": 0,
-          "extends": "class:core.Doc"
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectId: 'class:test.MyClass',
+        objectClass: 'class:core.Class',
+        objectSpace: 'space:core.Model',
+        attributes: {
+          kind: 0,
+          extends: 'class:core.Doc'
         }
       },
       {
-        "objectId": "class:test.MyClass",
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectSpace": "space:core.Model",
-        "objectClass": "class:core.Attribute",
-        "attributes": {
-          "type": {
-            "_class": "class:core.TypeString"
+        objectId: 'class:test.MyClass',
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectSpace: 'space:core.Model',
+        objectClass: 'class:core.Attribute',
+        attributes: {
+          type: {
+            _class: 'class:core.TypeString'
           },
-          "name": "name"
+          name: 'name'
         }
       }
     ])
@@ -78,69 +78,66 @@ describe('dsl', () => {
       _class!: Ref<Class<MyClass>>
       @Prop(TypeString()) name!: string
     }
-    @Model(
-      'class:test.MyClass2' as Ref<Class<Obj>>,
-      'class:test.MyClass' as Ref<Class<Obj>>
-    )
+    @Model('class:test.MyClass2' as Ref<Class<Obj>>, 'class:test.MyClass' as Ref<Class<Obj>>)
     class MyClass2 extends MyClass {
       @Prop(TypeString()) lastName!: string
     }
 
     const valid = [
       {
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectId": "class:test.MyClass",
-        "objectClass": "class:core.Class",
-        "objectSpace": "space:core.Model",
-        "attributes": {
-          "kind": 0,
-          "extends": "class:core.Doc"
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectId: 'class:test.MyClass',
+        objectClass: 'class:core.Class',
+        objectSpace: 'space:core.Model',
+        attributes: {
+          kind: 0,
+          extends: 'class:core.Doc'
         }
       },
       {
-        "objectId": "class:test.MyClass",
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectSpace": "space:core.Model",
-        "objectClass": "class:core.Attribute",
-        "attributes": {
-          "type": {
-            "_class": "class:core.TypeString"
+        objectId: 'class:test.MyClass',
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectSpace: 'space:core.Model',
+        objectClass: 'class:core.Attribute',
+        attributes: {
+          type: {
+            _class: 'class:core.TypeString'
           },
-          "name": "name"
+          name: 'name'
         }
       },
       {
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectId": "class:test.MyClass2",
-        "objectClass": "class:core.Class",
-        "objectSpace": "space:core.Model",
-        "attributes": {
-          "kind": 0,
-          "extends": "class:test.MyClass"
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectId: 'class:test.MyClass2',
+        objectClass: 'class:core.Class',
+        objectSpace: 'space:core.Model',
+        attributes: {
+          kind: 0,
+          extends: 'class:test.MyClass'
         }
       },
       {
-        "objectId": "class:test.MyClass2",
-        "_class": "class:core.TxCreateDoc",
-        "space": "space:core.Tx",
-        "modifiedBy": "account:core.System",
-        "modifiedOn": 0,
-        "objectSpace": "space:core.Model",
-        "objectClass": "class:core.Attribute",
-        "attributes": {
-          "type": {
-            "_class": "class:core.TypeString"
+        objectId: 'class:test.MyClass2',
+        _class: 'class:core.TxCreateDoc',
+        space: 'space:core.Tx',
+        modifiedBy: 'account:core.System',
+        modifiedOn: 0,
+        objectSpace: 'space:core.Model',
+        objectClass: 'class:core.Attribute',
+        attributes: {
+          type: {
+            _class: 'class:core.TypeString'
           },
-          "name": "lastName"
+          name: 'lastName'
         }
       }
     ]

--- a/packages/model/src/component.ts
+++ b/packages/model/src/component.ts
@@ -13,11 +13,7 @@
 // limitations under the License.
 //
 
-import type {
-  Attribute, Class,
-  PropertyType, Ref,
-  Type
-} from '@anticrm/core'
+import type { Attribute, Class, PropertyType, Ref, Type } from '@anticrm/core'
 import core from '@anticrm/core'
 import { mergeIds } from '@anticrm/status'
 


### PR DESCRIPTION
1. Reduce complexity and reformat model package
2. switch to eslint

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>