### PR TITLE
Collections Derived Data & $pull/dot search support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ After server is started, it will accept any incoming request for existing worksp
 docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/
 elasticsearch/elasticsearch:7.13.1
 ```
+
+## Dev tasks
+
+All dev required tasks could be execured from root of project using rushx tool.
+
+### Format all changed files
+
+`rushx format-diff`
+
+### Lint all changed files
+
+`rushx lint-diff`
+
+### Execute tests on modified projects
+
+`rushx test-diff`

--- a/common/changes/@anticrm/chunter/collection-dd_2021-07-20-07-58.json
+++ b/common/changes/@anticrm/chunter/collection-dd_2021-07-20-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/chunter",
+      "comment": "Collection DD",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/chunter",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/core/collection-dd_2021-07-20-07-58.json
+++ b/common/changes/@anticrm/core/collection-dd_2021-07-20-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/core",
+      "comment": "Collection DD",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/core",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/mongo/collection-dd_2021-07-20-07-58.json
+++ b/common/changes/@anticrm/mongo/collection-dd_2021-07-20-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/mongo",
+      "comment": "Collection DD",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/mongo",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/rpc/collection-dd_2021-07-20-07-58.json
+++ b/common/changes/@anticrm/rpc/collection-dd_2021-07-20-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/rpc",
+      "comment": "Collection DD",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/rpc",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/server/collection-dd_2021-07-20-07-58.json
+++ b/common/changes/@anticrm/server/collection-dd_2021-07-20-07-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/server",
+      "comment": "Collection DD",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/server",
+  "email": "haiodo@gmail.com"
+}

--- a/models/chunter/src/index.ts
+++ b/models/chunter/src/index.ts
@@ -28,7 +28,7 @@ export class TChannel extends TSpace implements Channel {}
 @Model(chunter.class.Message, core.class.Doc, DOMAIN_CHUNTER)
 export class TMessage extends TDoc implements Message {
   message!: string
-  replyCount!: number
+  comments!: Array<Ref<Comment>>
 }
 
 @Model(chunter.class.Comment, core.class.Doc, DOMAIN_CHUNTER)
@@ -94,6 +94,16 @@ export function createModel (builder: Builder): void {
           pattern: MARKDOWN_REFERENCE_PATTERN.source,
           multDoc: true
         }
+      }
+    ]
+  })
+  builder.createDoc(core.class.DerivedDataDescriptor, {
+    sourceClass: chunter.class.Comment,
+    targetClass: chunter.class.Message,
+    collections: [
+      {
+        sourceField: 'replyOf',
+        targetField: 'comments'
       }
     ]
   })

--- a/models/dev/src/demoChunter.ts
+++ b/models/dev/src/demoChunter.ts
@@ -28,8 +28,7 @@ export function demoChunter (builder: Builder): void {
     builder.createDoc(
       chunter.class.Message,
       {
-        message: faker.lorem.paragraphs(3),
-        replyCount: faker.datatype.number(10)
+        message: faker.lorem.paragraphs(3)
       },
       undefined,
       {

--- a/models/dev/src/demoTask.ts
+++ b/models/dev/src/demoTask.ts
@@ -68,8 +68,7 @@ export function demoTask (builder: Builder): void {
       builder.createDoc(
         chunter.class.Message,
         {
-          message: faker.lorem.paragraphs(3),
-          replyCount: 0
+          message: faker.lorem.paragraphs(3)
         },
         undefined,
         {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@anticrm/platform-root",
+  "version": "0.4.0",
+  "scripts": {
+    "test-diff": "./common/scripts/each-diff.sh rushx test",
+    "lint-diff": "./common/scripts/each-diff.sh rushx lint",
+    "lint-diff:fix": "./common/scripts/each-diff.sh rushx lint:fix",
+    "format-diff": "./common/scripts/each-diff.sh rushx format",
+    "dev": "cd ./dev/prod/ && rushx dev"
+  },
+  "author": "Anticrm Platform Contributors",
+  "license": "EPL-2.0"
+}

--- a/packages/core/src/__tests__/memdb.test.ts
+++ b/packages/core/src/__tests__/memdb.test.ts
@@ -14,31 +14,27 @@
 //
 
 import { describe, expect, it } from '@jest/globals'
-import type { Class, Doc, Obj, Ref } from '../classes'
+import type { Account, Class, Doc, Obj, Ref, Space } from '../classes'
 import core from '../component'
 import { Hierarchy } from '../hierarchy'
 import { ModelDb, TxDb } from '../memdb'
 import { SortingOrder } from '../storage'
-import { withOperations } from '../tx'
+import { TxUpdateDoc, withOperations } from '../tx'
 import { genMinModel } from './minmodel'
 
 const txes = genMinModel()
 
 describe('memdb', () => {
   it('should save all tx', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) hierarchy.tx(tx)
-    const txDb = new TxDb(hierarchy)
-    for (const tx of txes) await txDb.tx(tx)
+    const { txDb } = await prepareModel()
+
     const result = await txDb.findAll(core.class.Tx, {})
     expect(result.length).toBe(txes.filter((tx) => tx._class === core.class.TxCreateDoc).length)
   })
 
   it('should query model', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) await hierarchy.tx(tx)
-    const model = new ModelDb(hierarchy)
-    for (const tx of txes) await model.tx(tx)
+    const { model } = await prepareModel()
+
     const result = await model.findAll(core.class.Class, {})
     expect(result.length).toBeGreaterThan(5)
     const result2 = await model.findAll('class:workbench.Application' as Ref<Class<Doc>>, { _id: undefined })
@@ -46,10 +42,8 @@ describe('memdb', () => {
   })
 
   it('should allow delete', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) await hierarchy.tx(tx)
-    const model = new ModelDb(hierarchy)
-    for (const tx of txes) await model.tx(tx)
+    const { model } = await prepareModel()
+
     const result = await model.findAll(core.class.Space, {})
     expect(result.length).toBe(2)
 
@@ -60,10 +54,8 @@ describe('memdb', () => {
   })
 
   it('should query model with params', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) hierarchy.tx(tx)
-    const model = new ModelDb(hierarchy)
-    for (const tx of txes) await model.tx(tx)
+    const { model } = await prepareModel()
+
     const first = await model.findAll(core.class.Class, {
       _id: txes[1].objectId as Ref<Class<Obj>>,
       kind: 0
@@ -89,10 +81,8 @@ describe('memdb', () => {
   })
 
   it('should query model like params', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) hierarchy.tx(tx)
-    const model = new ModelDb(hierarchy)
-    for (const tx of txes) await model.tx(tx)
+    const { model } = await prepareModel()
+
     const expectedLength = txes.filter((tx) => tx.objectSpace === core.space.Model).length
     const without = await model.findAll(core.class.Doc, {
       space: { $like: core.space.Model }
@@ -121,20 +111,70 @@ describe('memdb', () => {
   })
 
   it('should push to array', async () => {
-    const hierarchy = new Hierarchy()
-    for (const tx of txes) await hierarchy.tx(tx)
-    const model = withOperations(core.account.System, new ModelDb(hierarchy))
-    for (const tx of txes) await model.tx(tx)
-    const space = await model.createDoc(core.class.Space, core.space.Model, {
+    const { model } = await prepareModel()
+
+    const client = withOperations(core.account.System, model)
+    const space = await client.createDoc(core.class.Space, core.space.Model, {
       name: 'name',
       description: 'desc',
       private: false,
       members: []
     })
-    const account = await model.createDoc(core.class.Account, core.space.Model, {})
-    await model.updateDoc(core.class.Space, core.space.Model, space._id, { $push: { members: account._id } })
-    const txSpace = await model.findAll(core.class.Space, { _id: space._id })
+    const account = await client.createDoc(core.class.Account, core.space.Model, {})
+    await client.updateDoc(core.class.Space, core.space.Model, space._id, { $push: { members: account._id } })
+    const txSpace = await client.findAll(core.class.Space, { _id: space._id })
     expect(txSpace[0].members).toEqual(expect.arrayContaining([account._id]))
+  })
+
+  it('check $push find', async () => {
+    const { model } = await prepareModel()
+
+    interface MyDoc extends Doc {
+      a: { b: number }
+    }
+    const doc: TxUpdateDoc<MyDoc> = {
+      _id: '60f58968abd82692921c51b4' as Ref<TxUpdateDoc<MyDoc>>,
+      _class: core.class.TxUpdateDoc,
+      space: core.space.Tx,
+      modifiedBy: 'john@appleseed.com' as Ref<Account>,
+      modifiedOn: 1626704232444,
+      objectId: '60f58968abd82692921c51b1' as Ref<MyDoc>,
+      objectClass: 'class:test.Task' as Ref<Class<Doc>>,
+      objectSpace: '60f58968abd82692921c51af' as Ref<Space>,
+      operations: {
+        a: { b: 23 },
+        $push: {
+          collections: 'abc'
+        }
+      }
+    }
+
+    model.addDoc(doc)
+
+    const d1 = await model.findAll(core.class.TxUpdateDoc, { 'operations.a.b': 23 })
+    expect(d1[0]._id).toEqual('60f58968abd82692921c51b4')
+
+    const d2 = await model.findAll(core.class.TxUpdateDoc, { 'operations.\\$push.collections': 'abc' })
+    expect(d2[0]._id).toEqual('60f58968abd82692921c51b4')
+  })
+
+  it('should pull from array', async () => {
+    const hierarchy = new Hierarchy()
+    for (const tx of txes) await hierarchy.tx(tx)
+    const model = withOperations(core.account.System, new ModelDb(hierarchy))
+    for (const tx of txes) await model.tx(tx)
+    const account1 = await model.createDoc(core.class.Account, core.space.Model, {})
+    const account2 = await model.createDoc(core.class.Account, core.space.Model, {})
+    const space = await model.createDoc(core.class.Space, core.space.Model, {
+      name: 'name',
+      description: 'desc',
+      private: false,
+      members: [account1._id, account2._id]
+    })
+    await model.updateDoc(core.class.Space, core.space.Model, space._id, { $pull: { members: account1._id } })
+    const txSpace = await model.findAll(core.class.Space, { _id: space._id })
+    expect(txSpace[0].members).toEqual(expect.arrayContaining([account2._id]))
+    expect(txSpace[0].members).not.toEqual(expect.arrayContaining([account1._id]))
   })
 
   it('limit and sorting', async () => {
@@ -162,3 +202,16 @@ describe('memdb', () => {
     expect(numberSort[0].modifiedOn).toBeLessThanOrEqual(numberSort[numberSortDesc.length - 1].modifiedOn)
   })
 })
+async function prepareModel (): Promise<{ model: ModelDb, hierarchy: Hierarchy, txDb: TxDb }> {
+  const hierarchy = new Hierarchy()
+  for (const tx of txes) {
+    hierarchy.tx(tx)
+  }
+  const model = new ModelDb(hierarchy)
+  for (const tx of txes) {
+    await model.tx(tx)
+  }
+  const txDb = new TxDb(hierarchy)
+  for (const tx of txes) await txDb.tx(tx)
+  return { model, hierarchy, txDb }
+}

--- a/packages/core/src/__tests__/txmodel.ts
+++ b/packages/core/src/__tests__/txmodel.ts
@@ -1,0 +1,26 @@
+import { Class, Doc, Ref } from '../classes'
+import { Hierarchy } from '../hierarchy'
+import { DocumentQuery, FindResult, Storage } from '../storage'
+import { DOMAIN_TX, Tx } from '../tx'
+
+export class TxModelStorage implements Storage {
+  constructor (readonly hierarchy: Hierarchy, readonly txStore: Storage, readonly doc: Storage) {}
+
+  txStorage (): Storage {
+    return this.txStore
+  }
+
+  async findAll<T extends Doc>(_class: Ref<Class<T>>, query: DocumentQuery<T>): Promise<FindResult<T>> {
+    const domain = this.hierarchy.getDomain(_class)
+    if (domain === DOMAIN_TX) {
+      return await this.txStore.findAll(_class, query)
+    }
+    return await this.doc.findAll(_class, query)
+  }
+
+  async tx (tx: Tx): Promise<void> {
+    await this.doc.tx(tx)
+
+    await this.txStore.tx(tx) // In any case send into transaction storage.
+  }
+}

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -142,7 +142,9 @@ export async function createClient (
 async function withDerivedDataProcessor (client: ClientImpl): Promise<Client> {
   // D E R I V E D   D A T A
   const ddProcessor = await DerivedDataProcessor.create(client.model, client.hierarchy, newClientOnlyStorage(client))
-  client.extraTx = async (tx: Tx) => await ddProcessor.tx(tx)
+  client.extraTx = async (tx: Tx) => {
+    await ddProcessor.tx(tx)
+  }
 
   return client
 }

--- a/packages/core/src/derived/index.ts
+++ b/packages/core/src/derived/index.ts
@@ -49,6 +49,14 @@ export interface MappingRule {
 }
 
 /**
+ * An collection update rule, if defined, our document _id will be push/pull to/from objectId specified in our refField.
+ */
+export interface CollectionRule {
+  sourceField: string // A field reference to source object.
+  targetField: string // A source field collection we need to push our _id inside.
+}
+
+/**
  * Document describing derived data
  */
 export interface DerivedDataDescriptor<T extends Doc, D extends DerivedData> extends Doc {
@@ -70,6 +78,11 @@ export interface DerivedDataDescriptor<T extends Doc, D extends DerivedData> ext
    * If rule is matched multiple times, multiple derived data documents will be created.
    */
   rules?: MappingRule[]
+
+  /**
+   * An collection rules.
+   */
+  collections?: CollectionRule[]
 }
 
 /**

--- a/packages/core/src/derived/utils.ts
+++ b/packages/core/src/derived/utils.ts
@@ -1,6 +1,7 @@
 import { deepEqual } from 'fast-equals'
 import { DerivedData, DerivedDataDescriptor, MappingRule, RuleExpresson } from '.'
 import { Data, Doc } from '../classes'
+import { generateId } from '../utils'
 
 type Descr = DerivedDataDescriptor<Doc, DerivedData>
 export interface DerivedDataOperations {
@@ -53,7 +54,7 @@ export function newDerivedData<T extends DerivedData> (doc: Doc, d: Descr, len: 
     objectId: doc._id,
     objectClass: doc._class,
     ...(d.initiValue ?? {}),
-    _id: `dd-${doc._id}-${len}`,
+    _id: `dd-${generateId()}`,
     modifiedBy: doc.modifiedBy,
     modifiedOn: Date.now(),
     space: doc.space,

--- a/packages/core/src/operator.ts
+++ b/packages/core/src/operator.ts
@@ -21,7 +21,7 @@ type OperatorFunc = (doc: Doc, op: object) => void
 function $push (document: Doc, keyval: Record<string, PropertyType>): void {
   const doc = document as any
   for (const key in keyval) {
-    const arr = doc[key]
+    const arr: Array<any> = doc[key]
     if (arr === undefined) {
       doc[key] = [keyval[key]]
     } else {
@@ -29,9 +29,19 @@ function $push (document: Doc, keyval: Record<string, PropertyType>): void {
     }
   }
 }
+function $pull (document: Doc, keyval: Record<string, PropertyType>): void {
+  const doc = document as any
+  for (const key in keyval) {
+    const arr: Array<any> = doc[key]
+    if (arr !== undefined) {
+      doc[key] = arr.filter((k) => k !== keyval[key])
+    }
+  }
+}
 
 const operators: Record<string, OperatorFunc> = {
-  $push
+  $push,
+  $pull
 }
 
 export function getOperator (name: string): OperatorFunc {

--- a/packages/core/src/query.ts
+++ b/packages/core/src/query.ts
@@ -20,11 +20,30 @@ export function findProperty (objects: Doc[], propertyKey: string, value: any): 
   }
   const result: Doc[] = []
   for (const object of objects) {
-    if ((object as any)[propertyKey] === value) {
+    const val = (object as any)[propertyKey]
+    if (val === value || nestedDotQueryCheck(propertyKey, object, value)) {
       result.push(object)
     }
   }
   return result
+}
+
+function nestedDotQueryCheck (key: string, value: any, pattern: any): boolean {
+  // Check dot notation
+
+  // Replace escapting, since memdb is not escape keys
+  key = key.split('\\$').join('$')
+  const dots = key.split('.')
+  if (dots.length > 1) {
+    // We have dots, so iterate in depth
+    for (const d of dots) {
+      value = value?.[d]
+    }
+    if (value === pattern) {
+      return true
+    }
+  }
+  return false
 }
 
 export function resultSort<T extends Doc> (result: T[], sortOptions: SortingQuery<T>): void {

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -24,9 +24,16 @@ export type QuerySelector<T> = {
 
 export type ObjQueryType<T> = T | QuerySelector<T>
 
+export interface NestedDotQuery {
+  // support nested queries e.g. 'user.friends.name'
+  // this will mark all unrecognized properties as any (including nested queries)
+  [key: string]: any
+}
+
 export type DocumentQuery<T extends Doc> = {
   [P in keyof T]?: ObjQueryType<T[P]>
-}
+} &
+NestedDotQuery
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type FindOptions<T extends Doc> = {

--- a/packages/core/src/tx.ts
+++ b/packages/core/src/tx.ts
@@ -36,11 +36,12 @@ type ArrayAsElement<T extends Doc> = {
 
 type OmitNever<T extends object> = Omit<T, KeysByType<T, never>>
 
-interface PushOptions<T extends Doc> {
+interface DocOperation<T extends Doc> {
   $push?: Partial<OmitNever<ArrayAsElement<T>>>
+  $pull?: Partial<OmitNever<ArrayAsElement<T>>>
 }
 
-export type DocumentUpdate<T extends Doc> = Partial<Data<T>> & PushOptions<T>
+export type DocumentUpdate<T extends Doc> = Partial<Data<T>> & DocOperation<T>
 
 export interface TxUpdateDoc<T extends Doc> extends Tx<T> {
   objectClass: Ref<Class<T>>

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -96,6 +96,7 @@ export abstract class RequestProcessor {
       const req = this.requests.get(response.id)
       if (req !== undefined) {
         if (response.error !== undefined) {
+          console.error(response.error)
           req.reject(new PlatformError(response.error))
           return
         } else {

--- a/plugins/chunter/src/index.ts
+++ b/plugins/chunter/src/index.ts
@@ -22,7 +22,7 @@ export interface Channel extends Space {}
 
 export interface Message extends Doc {
   message: string
-  replyCount: number
+  comments?: Array<Ref<Comment>>
 }
 
 export interface Comment extends Doc {

--- a/server/mongo/src/escaping.ts
+++ b/server/mongo/src/escaping.ts
@@ -1,0 +1,54 @@
+//
+// Copyright © 2021 Anticrm Platform Contributors.
+//
+// Licensed under the Eclipse Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may
+// obtain a copy of the License at https://www.eclipse.org/legal/epl-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+function keyEscape (key: string, reverse: boolean): string {
+  const kk = ['$', '\\$']
+  key = key.split(kk[reverse ? 1 : 0]).join(kk[reverse ? 0 : 1])
+  return key
+}
+
+function escape<T> (object: T, reverse: boolean): T {
+  if (Array.isArray(object)) {
+    return escapeArray(object, reverse)
+  }
+  return isObject<T>(object) ? escapeObject(object, reverse) : object
+}
+function isObject<T> (object: T): boolean {
+  return object != null && typeof object === 'object'
+}
+
+function escapeObject<T> (object: T, reverse: boolean): T {
+  const result: any = {}
+  for (const [k, v] of Object.entries(object)) {
+    result[keyEscape(k, reverse)] = escape(v, reverse)
+  }
+  return result as T
+}
+function escapeArray<T> (object: T & any[], reverse: boolean): T {
+  return object.map((t) => escape(t, reverse)) as unknown as T
+}
+
+/**
+ * Return object with all keys started with $ escaped.
+ */
+export function mongoEscape<T> (object: T): T {
+  return escape(object, false)
+}
+/**
+ * Return object with all keys started with $ un-escaped.
+ */
+export function mongoUnescape<T> (object: T): T {
+  return escape(object, true)
+}

--- a/server/mongo/src/query.ts
+++ b/server/mongo/src/query.ts
@@ -38,7 +38,7 @@ export function toMongoQuery<T extends Doc> (
   for (const key in query) {
     const value = query[key]
     if (typeof value !== 'object') continue
-    mongoQuery[key] = translateQuery(value as any)
+    mongoQuery[key] = translateQuery(value)
   }
 
   mongoQuery._class = objectClass

--- a/server/mongo/src/tx.ts
+++ b/server/mongo/src/tx.ts
@@ -16,6 +16,7 @@
 import { Class, DocumentQuery, FindOptions, FindResult, Hierarchy, Storage, Tx } from '@anticrm/core'
 import { Doc, Ref } from '@anticrm/core/src/classes'
 import { Collection } from 'mongodb'
+import { mongoEscape, mongoUnescape } from './escaping'
 import { toMongoQuery } from './query'
 
 /**
@@ -28,7 +29,7 @@ export class TxStorage implements Storage {
   }
 
   async tx (tx: Tx): Promise<void> {
-    await this.db.insertOne(tx)
+    await this.db.insertOne(mongoEscape(tx))
   }
 
   async findAll<T extends Doc>(
@@ -41,6 +42,10 @@ export class TxStorage implements Storage {
     if (options?.sort !== undefined) cursor = cursor.sort(options.sort)
     const total = await cursor.count()
     if (options?.limit !== undefined) cursor = cursor.limit(options.limit)
-    return Object.assign(await cursor.toArray(), { total })
+    const resultArray = await cursor.toArray()
+    return Object.assign(
+      resultArray.map((v) => mongoUnescape(v)),
+      { total }
+    )
   }
 }

--- a/server/server/src/__tests__/client.server.test.ts
+++ b/server/server/src/__tests__/client.server.test.ts
@@ -13,23 +13,55 @@
 // limitations under the License.
 //
 
-import core, { Account, DOMAIN_TX, generateId, Ref, Tx, DerivedDataDescriptor, Doc, Class, Title } from '@anticrm/core'
+import core, {
+  Account,
+  Class,
+  DerivedDataDescriptor,
+  Doc,
+  DOMAIN_TX,
+  generateId,
+  Ref,
+  Reference,
+  Title,
+  Tx
+} from '@anticrm/core'
+import { Domain } from '@anticrm/core/src/classes'
+import { createClass, createDoc } from '@anticrm/core/src/__tests__/minmodel'
 import builder from '@anticrm/model-all'
+import { getMongoClient, shutdown } from '@anticrm/mongo'
+import { dropAllDBWithPrefix } from '@anticrm/mongo/src/__tests__/storage.test'
+import { component, Component } from '@anticrm/status'
 import { describe, it } from '@jest/globals'
-import { getMongoClient } from '@anticrm/mongo'
+import * as net from 'net'
 import { start } from '../server'
 import { decodeToken, generateToken } from '../token'
 import { assignWorkspace, closeWorkspace } from '../workspaces'
 import { createClient } from './client'
-import * as net from 'net'
-import { createDoc } from '@anticrm/core/src/__tests__/minmodel'
-import { Reference } from '../../../../packages/core/lib/reference'
 
 const SERVER_SECRET = 'secret'
 const MONGO_URI = 'mongodb://localhost:27017'
 
 const johnAccount = 'john@appleseed.com' as Ref<Account>
 const brianAccount = 'brian@appleseed.com' as Ref<Account>
+
+interface Task extends Doc {
+  shortId: string
+  title: string
+  description: string
+  comments?: Array<Ref<Comment>>
+}
+
+interface Comment extends Doc {
+  ofDoc: Ref<Doc>
+  message: string
+}
+
+const testIds = component('test' as Component, {
+  class: {
+    Task: '' as Ref<Class<Task>>,
+    Comment: '' as Ref<Class<Comment>>
+  }
+})
 
 async function prepareServer (): Promise<{ shutdown: () => Promise<void>, address: net.AddressInfo }> {
   const client = await getMongoClient(MONGO_URI)
@@ -41,12 +73,14 @@ async function prepareServer (): Promise<{ shutdown: () => Promise<void>, addres
     throw Error('workspace already exists')
   }
   const txes = db.collection(DOMAIN_TX as string)
-  const btx = builder.getTxes()
+  const btx = [...builder.getTxes()]
 
-  btx.push(createDoc(core.class.Account, {}, johnAccount))
-  btx.push(createDoc(core.class.Account, {}, brianAccount))
-
+  // Test ids
   btx.push(
+    createClass(testIds.class.Task, { extends: core.class.Doc, domain: 'task' as Domain }),
+    createClass(testIds.class.Comment, { extends: core.class.Doc, domain: 'task' as Domain }),
+    createDoc(core.class.Account, {}, johnAccount),
+    createDoc(core.class.Account, {}, brianAccount),
     createDoc<DerivedDataDescriptor<Title, Reference>>(core.class.DerivedDataDescriptor, {
       sourceClass: core.class.Title,
       targetClass: core.class.Reference,
@@ -54,6 +88,16 @@ async function prepareServer (): Promise<{ shutdown: () => Promise<void>, addres
         {
           sourceField: 'title',
           targetField: 'link'
+        }
+      ]
+    }),
+    createDoc<DerivedDataDescriptor<Title, Reference>>(core.class.DerivedDataDescriptor, {
+      sourceClass: testIds.class.Comment,
+      targetClass: testIds.class.Task,
+      collections: [
+        {
+          sourceField: 'ofDoc',
+          targetField: 'comments'
         }
       ]
     })
@@ -71,7 +115,7 @@ async function prepareServer (): Promise<{ shutdown: () => Promise<void>, addres
         console.log(`Connected Client ${clientId} with account: ${accountId} to ${workspaceId} `)
         return await assignWorkspace({ clientId, accountId, workspaceId, tx: sendTx })
       } catch (err) {
-        throw new Error('invalid token')
+        throw new Error(`invalid token ${JSON.stringify(err, undefined, 2)}`)
       }
     },
     close: async (clientId) => {
@@ -82,28 +126,41 @@ async function prepareServer (): Promise<{ shutdown: () => Promise<void>, addres
   return {
     shutdown: async () => {
       server.shutdown()
-      console.log('dropping db')
-      await db.dropDatabase()
-      await client.close(true)
     },
     address: server.address()
   }
 }
 
-describe('real=server', () => {
-  let shutdown: () => Promise<void>
+describe('real-server', () => {
+  let serverShutdown: () => Promise<void>
   let address: net.AddressInfo
+  const mongodbUri: string = process.env.MONGODB_URI ?? 'mongodb://localhost:27017'
+
+  async function cleanDbs (): Promise<void> {
+    const mongoClient = await getMongoClient(mongodbUri)
+    await dropAllDBWithPrefix('ws-s-test', mongoClient)
+  }
+
+  beforeAll(async () => {
+    await cleanDbs()
+  })
+
+  afterAll(async () => {
+    await cleanDbs()
+    await shutdown()
+    console.log('clean after all done')
+  })
 
   beforeEach(async () => {
     console.log('staring server')
     const s = await prepareServer()
     console.log('server ok')
-    shutdown = s.shutdown
+    serverShutdown = s.shutdown
     address = s.address
   })
 
   afterEach(async () => {
-    return await shutdown()
+    return await serverShutdown()
   })
 
   it('client connect server', async () => {
@@ -145,5 +202,51 @@ describe('real=server', () => {
 
     const c2r = await client2.findAll(core.class.Reference, {})
     expect(c2r.length).toEqual(1)
+    console.info('TEST1 PASS')
+  })
+
+  it('check comments dd', async () => {
+    console.log('connecting')
+    const johnTxes: Tx[] = []
+    const client = await createClient(
+      `${address.address}:${address.port}/${generateToken(SERVER_SECRET, johnAccount as string, '')}`,
+      (tx) => {
+        johnTxes.push(tx)
+      }
+    )
+
+    const brainTxes: Tx[] = []
+    const client2 = await createClient(
+      `${address.address}:${address.port}/${generateToken(SERVER_SECRET, brianAccount as string, '')}`,
+      (tx) => {
+        brainTxes.push(tx)
+      }
+    )
+
+    const sp1 = await client.createDoc(core.class.Space, core.space.Model, {
+      name: 'test-space',
+      members: [johnAccount, brianAccount],
+      description: 'test space',
+      private: true
+    })
+
+    const t1 = await client.createDoc(testIds.class.Task, sp1._id, {
+      title: 't1',
+      shortId: 'id1' as Ref<Doc>,
+      description: 'test'
+    })
+
+    await client.createDoc(testIds.class.Comment, sp1._id, {
+      ofDoc: t1._id,
+      message: 'Comment'
+    })
+    await client.createDoc(testIds.class.Comment, sp1._id, {
+      ofDoc: t1._id,
+      message: 'Comment 2'
+    })
+
+    const t12 = await client2.findAll(testIds.class.Task, {})
+    expect(t12.length).toEqual(1)
+    expect(t12[0].comments?.length).toEqual(2)
   })
 })


### PR DESCRIPTION
1. Support collection Derived Data, so it possible to automated update of object collection of references to some joined objects.

```typescript
interface Task extends Doc {
  shortId: string
  title: string
  description: string
  comments?: Array<Ref<Comment>>
}

interface Comment extends Doc {
  ofDoc: Ref<Doc>
  message: string
}

//// And Derived Data
createDoc<DerivedDataDescriptor<Title, Reference>>(core.class.DerivedDataDescriptor, {
  sourceClass: testIds.class.Comment,
  targetClass: testIds.class.Task,
  collections: [ {
    sourceField: 'ofDoc',
    targetField: 'comments'
  }]
})
```

2. Support of $pull operator to remove element from stored object array.

```typescript
await client.updateDoc(core.class.Space, core.space.Model, space._id, { $pull: { members: account1._id } })
```

3. Support of dot notation search, for embedded object field values.

```typescript
const pushOps = await ops.findAll<TxUpdateDoc<Doc>>(core.class.TxUpdateDoc, {
  objectClass: d.targetClass,
  [`operations.\\$push.${r.targetField}`]: tx.objectId
})
```

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>