### PR TITLE
Minor space header fixes

### DIFF
--- a/common/changes/@anticrm/workbench-impl/fix-space-header_2021-11-12-10-19.json
+++ b/common/changes/@anticrm/workbench-impl/fix-space-header_2021-11-12-10-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@anticrm/workbench-impl",
+      "comment": "Fix spac header issues",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@anticrm/workbench-impl"
+}

--- a/plugins/workbench-impl/src/components/SpaceHeader.svelte
+++ b/plugins/workbench-impl/src/components/SpaceHeader.svelte
@@ -14,6 +14,7 @@
 -->
 <script lang="ts">
   import { Space } from '@anticrm/core'
+  import { AnyComponent } from '@anticrm/status'
   import ui, { ActionIcon, Button, Component, Icon, showPopup } from '@anticrm/ui'
   import type { SpacesNavModel } from '@anticrm/workbench'
   import { getClient } from '@anticrm/workbench'
@@ -50,6 +51,17 @@
       )
     }
   }
+  const showOptions = () => {
+    const view = spaceModel?.spaceMore as AnyComponent
+    return showPopup(
+      view,
+      {
+        _class: spaceModel?.spaceClass,
+        space
+      },
+      'right'
+    )
+  }
 </script>
 
 <div class="flex-between header">
@@ -75,18 +87,22 @@
     {/if}
   </div>
   <div class="flex-row-center">
-    <Button
-      label={spaceModel?.item?.createLabel ?? ui.string.Create}
-      size={'small'}
-      primary
-      on:click={(ev) => {
-        addAction(ev)
-      }}
-    />
+    {#if spaceModel?.item?.createComponent}
+      <Button
+        label={spaceModel?.item?.createLabel ?? ui.string.Create}
+        size={'small'}
+        primary
+        on:click={(ev) => {
+          addAction(ev)
+        }}
+      />
+    {/if}
     <div class="button button-8">
       <ActionIcon icon={Star} size={16} action={changeStarred} filled={space?.account?.starred ?? false} />
     </div>
-    <div class="button button-4"><ActionIcon icon={MoreH} size={16} /></div>
+    {#if spaceModel?.spaceMore}
+      <div class="button button-4"><ActionIcon icon={MoreH} size={16} action={showOptions} /></div>
+    {/if}
   </div>
 </div>
 


### PR DESCRIPTION
1. Space header should not show Create button if there is no create action.
2. Space header should show options only if they are available and open appropriate popup on click.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>