### PR TITLE
Fix Markdown editor and reference input

### DIFF
--- a/common/changes/@anticrm/chunter-impl/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/chunter-impl/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/chunter-impl"
+    }
+  ],
+  "packageName": "@anticrm/chunter-impl",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/recruiting-impl/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/recruiting-impl/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/recruiting-impl"
+    }
+  ],
+  "packageName": "@anticrm/recruiting-impl",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/richeditor/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/richeditor/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/richeditor"
+    }
+  ],
+  "packageName": "@anticrm/richeditor",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/task-impl/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/task-impl/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/task-impl"
+    }
+  ],
+  "packageName": "@anticrm/task-impl",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/text/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/text/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/text"
+    }
+  ],
+  "packageName": "@anticrm/text",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/ui/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/ui/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/ui"
+    }
+  ],
+  "packageName": "@anticrm/ui",
+  "email": "haiodo@gmail.com"
+}

--- a/common/changes/@anticrm/workbench-impl/fix-548_2021-11-13-15-12.json
+++ b/common/changes/@anticrm/workbench-impl/fix-548_2021-11-13-15-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Markdown editor fix",
+      "type": "patch",
+      "packageName": "@anticrm/workbench-impl"
+    }
+  ],
+  "packageName": "@anticrm/workbench-impl",
+  "email": "haiodo@gmail.com"
+}

--- a/packages/richeditor/src/MessageEditor.svelte
+++ b/packages/richeditor/src/MessageEditor.svelte
@@ -23,6 +23,7 @@ export let content: MessageNode
 export let triggers: string[] = []
 export let transformInjections: StateTransformer | undefined = undefined
 export let enterNewLine: boolean = false
+export let keydownHandler: ((event: KeyboardEvent) => boolean) | undefined
 
 // ********************************
 // Functionality
@@ -151,24 +152,41 @@ const focusPlugin = new Plugin({
       blur: () => {
         dispatch('blur')
         hasFocus = false
+        return false
       },
       focus: () => {
         hasFocus = true
+        return false
       }
     }
   }
 })
 
+const keyDownKey = new PluginKey('preventKeydownPlugin')
+const keydownPlugin = new Plugin({
+  key: keyDownKey,
+  props: {
+    handleKeyDown: (view, event) => {
+      if (keydownHandler !== undefined) {
+        return keydownHandler(event)
+      }
+      return false
+    }
+  }
+})
+
 function createState (doc: MessageNode): EditorState {
+  const plugins = [
+    history(),
+    buildInputRules(),
+    keydownPlugin,
+    keymap(buildKeymap(!enterNewLine)),
+    focusPlugin
+  ]
   return EditorState.fromJSON(
     {
       schema,
-      plugins: [
-        history(),
-        buildInputRules(),
-        keymap(buildKeymap(!enterNewLine)),
-        focusPlugin
-      ]
+      plugins
     },
     {
       doc: doc,

--- a/packages/text/src/__tests__/textmodel.test.ts
+++ b/packages/text/src/__tests__/textmodel.test.ts
@@ -27,6 +27,17 @@ describe('server', () => {
 
     expect(msg).toEqual('Hello [Page1](ref://chunter.Page#5f8043dc1b592de172c26181) and [Page3](ref://Page#)')
   })
+  it('Check reference conversion', () => {
+    const t1 =
+      '{"content":[{"content":[{"text":"Hello ","type":"text"},{"marks":[{"attrs":{"class":"class:chunter.Page","id":"5f8043dc1b592de172c26181"},"type":"reference"}],"text":"[[Page1]]","type":"text"},{"text":" and ","type":"text"},{"marks":[{"attrs":{"class":"Page","id":null},"type":"reference"}],"text":"[[Page3]]","type":"text"}],"type":"paragraph"}],"type":"doc"}'
+    const msg = serializeMessage(JSON.parse(t1) as MessageNode)
+    const parsed = parseMessage(msg, true)
+
+    const pm = JSON.stringify(parsed)
+    console.log(pm)
+    expect((parsed as any).content[0].content[1].text).toEqual('[[Page1]]')
+    expect((parsed as any).content[0].content[3].text).toEqual('[[Page3]]')
+  })
   it('check list with bold and italic', () => {
     const msg = serializeMessage(
       JSON.parse(

--- a/packages/text/src/index.ts
+++ b/packages/text/src/index.ts
@@ -23,15 +23,15 @@ export { traverseAllMarks } from './node'
 /**
  * @public
  */
-export function parseMessage (message: string): MessageNode {
-  return parseMessageMarkdown(message)
+export function parseMessage (message: string, convertReferences?: boolean): MessageNode {
+  return parseMessageMarkdown(message, convertReferences)
 }
 
 /**
  * @public
  */
-export function parseMessageMarkdown (message?: string): MessageNode {
-  const parser = new MarkdownParser()
+export function parseMessageMarkdown (message?: string, convertReferences?: boolean): MessageNode {
+  const parser = new MarkdownParser(convertReferences)
   return parser.parse(message ?? '')
 }
 

--- a/packages/ui/src/components/Component.svelte
+++ b/packages/ui/src/components/Component.svelte
@@ -26,11 +26,19 @@
   export let scrollable: boolean = false
   export let maxHeight: number = 0
 
+  let componentInstance: any
+
   function asComponent (comp: AnyComponent | string): AnyComponent {
     return comp as AnyComponent
   }
 
   $: component = typeof is === 'string' ? getResource(asComponent(is)) : is
+
+  $: {
+    if (componentInstance) {
+      dispatch('bindThis', componentInstance)
+    }
+  }
 
   const dispatch = createEventDispatcher()
 </script>
@@ -41,6 +49,7 @@
   <ErrorBoundary>
     <svelte:component
       this={Ctor}
+      bind:this={componentInstance}
       {...props}
       {scrollable}
       {maxHeight}

--- a/packages/ui/src/components/Popup.svelte
+++ b/packages/ui/src/components/Popup.svelte
@@ -24,6 +24,7 @@
     element={popup.element}
     onClose={popup.onClose}
     zIndex={(i + 1) * 500}
-    enableOverlay={i === 0}
+    overrideOverlay={i === 0}
+    bindPromise={popup.bindPromise}
   />
 {/each}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,13 +18,13 @@ import Root from './components/internal/Root.svelte'
 
 import type { IntlString } from '@anticrm/platform'
 import { writable } from 'svelte/store'
-import type { LabelAndProps, TooltipAligment, PopupAlignment } from './types'
-import { DeferredPromise } from '@anticrm/core'
+import type { LabelAndProps, TooltipAligment } from './types'
 
 export * from './types'
 export { applicationShortcutKey, defaultApplicationShortcutKey } from './utils'
 export * from './location'
 export * from './router'
+export * from './popups'
 
 export { default as EditBox } from './components/EditBox.svelte'
 export { default as EditWithIcon } from './components/EditWithIcon.svelte'
@@ -101,38 +101,6 @@ export { default } from './component'
 
 export function createApp (target: HTMLElement): UIComponent {
   return new Root({ target })
-}
-
-interface CompAndProps {
-  is: UIComponent
-  props: any
-  element?: PopupAlignment
-  onClose?: (result: any) => void
-  hidePromise: DeferredPromise<void>
-}
-
-export const popupstore = writable<CompAndProps[]>([])
-
-export async function showPopup (
-  component: UIComponent,
-  props: any,
-  element?: PopupAlignment,
-  onClose?: (result: any) => void
-): Promise<void> {
-  const p = new DeferredPromise<void>()
-  popupstore.update((popups) => {
-    popups.push({ is: component, props, element, onClose, hidePromise: p })
-    return popups
-  })
-  return await p.promise
-}
-
-export function closePopup (): void {
-  popupstore.update((popups) => {
-    const pp = popups.pop()
-    pp?.hidePromise.resolve()
-    return popups
-  })
 }
 
 export const tooltipstore = writable<LabelAndProps>({

--- a/packages/ui/src/popups.ts
+++ b/packages/ui/src/popups.ts
@@ -1,0 +1,76 @@
+import { DeferredPromise, generateId } from '@anticrm/core'
+import type { UIComponent } from '@anticrm/status'
+import { writable } from 'svelte/store'
+import type { PopupAlignment } from './types'
+
+export interface PopupInstance {
+  // Immidiate close of control
+  close: () => void
+  // Return a control bind.
+  bind: Promise<any>
+  // Will be resolved on popup close
+  hide: Promise<void>
+}
+
+interface PopupInstanceImpl extends PopupInstance {
+  id: string
+  is: UIComponent
+  props: any
+  element?: PopupAlignment
+  onClose?: (result: any) => void
+  hidePromise: DeferredPromise<void>
+  bindPromise: DeferredPromise<any>
+  overrideOverlay?: boolean
+}
+
+export const popupstore = writable<PopupInstanceImpl[]>([])
+
+export function showPopup (
+  component: UIComponent,
+  props: any,
+  element?: PopupAlignment,
+  onClose?: (result: any) => void,
+  overrideOverlay?: boolean
+): PopupInstance {
+  const hidePromise = new DeferredPromise<void>()
+  const bindPromise = new DeferredPromise<void>()
+  const id = generateId()
+  const data: PopupInstanceImpl = {
+    id,
+    is: component,
+    props,
+    element,
+    onClose,
+    hidePromise,
+    bindPromise,
+    close: () => {
+      doClose(id)
+    },
+    bind: bindPromise.promise,
+    hide: hidePromise.promise,
+    overrideOverlay
+  }
+
+  popupstore.update((popups) => {
+    popups.push(data)
+    return popups
+  })
+  return data
+}
+
+export function closePopup (): void {
+  doClose()
+}
+
+function doClose (id?: string): void {
+  popupstore.update((popups) => {
+    const pp = popups.pop()
+    if (pp !== undefined && id !== undefined && pp?.id !== id) {
+      console.error(new Error(`Cannot close popup with id: ${id}`))
+      popups.push(pp)
+      return popups
+    }
+    pp?.hidePromise.resolve()
+    return popups
+  })
+}

--- a/plugins/chunter-impl/src/components/Message.svelte
+++ b/plugins/chunter-impl/src/components/Message.svelte
@@ -278,7 +278,7 @@
             currentSpace={message.space}
             objectId={message._id}
             objectClass={message._class}
-            editorContent={parseMessage(message.message)}
+            editorContent={parseMessage(message.message, true)}
             on:update={(detail) => {
               newMessageValue = serializeMessage(detail.detail)
             }}

--- a/plugins/chunter-impl/src/components/ReferenceInput.svelte
+++ b/plugins/chunter-impl/src/components/ReferenceInput.svelte
@@ -208,33 +208,31 @@
     htmlEditor.focus()
   }
 
-  function onKeyDown (event: any): void {
+  function onKeyDown (event: KeyboardEvent): boolean {
     if (popupVisible) {
       if (event.key === 'ArrowUp') {
         completionControl.handleUp()
-        event.preventDefault()
-        return
+        return true
       }
       if (event.key === 'ArrowDown') {
         completionControl.handleDown()
-        event.preventDefault()
-        return
+        return true
       }
       if (event.key === 'Enter') {
         completionControl.handleSubmit()
-        event.preventDefault()
-        return
+        return true
       }
       if (event.key === 'Escape') {
         completions = []
         popupVisible = false
-        return
+        return true
       }
     }
     if (event.key === 'Enter' && !event.shiftKey) {
       handleSubmit()
-      event.preventDefault()
+      return true
     }
+    return false
   }
 
   function handleSubmit (): void {
@@ -311,13 +309,13 @@
         class="inputMsg"
         class:edit-box-vertical={stylesEnabled}
         class:edit-box-horizontal={!stylesEnabled}
-        on:keydown={onKeyDown}
         on:drop|preventDefault={drop}
         on:dragover|preventDefault
       >
         <MessageEditor
           bind:this={htmlEditor}
           bind:content={editorContent}
+          keydownHandler={onKeyDown}
           {triggers}
           transformInjections={transformFunction}
           on:content={(event) => {
@@ -342,7 +340,7 @@
                 right: styleState.cursor.right + 15,
                 bottom: styleState.cursor.bottom - styleState.inputHeight
               }}
-              on:select={(e) => handlePopupSelected(e.detail)}
+              handler={(e) => handlePopupSelected(e)}
             />
           {/if}
         </MessageEditor>

--- a/plugins/recruiting-impl/src/components/applicants/ApplicantTable.svelte
+++ b/plugins/recruiting-impl/src/components/applicants/ApplicantTable.svelte
@@ -18,7 +18,7 @@
   import type { Applicant, VacancySpace } from '@anticrm/recruiting'
   import recruiting from '@anticrm/recruiting'
   import type { QueryUpdater } from '@anticrm/presentation'
-  import { closePopup, Label, showPopup, Table } from '@anticrm/ui'
+  import { Label, showPopup, Table } from '@anticrm/ui'
   import ApplicantPresenter from './ApplicantPresenter.svelte'
 
   export let space: VacancySpace
@@ -42,9 +42,7 @@
   ]
 
   function onClick (event: any) {
-    showPopup(ApplicantPresenter, { id: event.detail._id }, 'full', () => {
-      closePopup()
-    })
+    showPopup(ApplicantPresenter, { id: event.detail._id }, 'full')
   }
 
   let applicants: Applicant[] = []

--- a/plugins/recruiting-impl/src/components/candidates/CandidateTable.svelte
+++ b/plugins/recruiting-impl/src/components/candidates/CandidateTable.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import { Table, Label, showPopup, closePopup, YesNo } from '@anticrm/ui'
+  import { Table, Label, showPopup, YesNo } from '@anticrm/ui'
   import type { Doc, Ref, Space } from '@anticrm/core'
   import { getClient } from '@anticrm/workbench'
   import type { Candidate } from '@anticrm/recruiting'
@@ -91,9 +91,7 @@
   }
 
   function onClick (event: any) {
-    showPopup(EditCandidate, { id: event.detail._id }, 'full', () => {
-      closePopup()
-    })
+    showPopup(EditCandidate, { id: event.detail._id }, 'full')
   }
 </script>
 

--- a/plugins/task-impl/src/components/Card.svelte
+++ b/plugins/task-impl/src/components/Card.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import ui, { ActionIcon, closePopup, Progress, showPopup, UserInfo } from '@anticrm/ui'
+  import ui, { ActionIcon, Progress, showPopup, UserInfo } from '@anticrm/ui'
   import MoreH from './icons/MoreH.svelte'
   import Chat from './icons/Chat.svelte'
   import type { Task } from '@anticrm/task'
@@ -46,9 +46,7 @@
   }
 
   function select () {
-    showPopup(EditTask, { id: card._id }, 'full', () => {
-      closePopup()
-    })
+    showPopup(EditTask, { id: card._id }, 'full')
   }
 
   function isNew (card: Task, spaceLastViews: SpaceLastViews | undefined): boolean {

--- a/plugins/task-impl/src/components/KanbanCard.svelte
+++ b/plugins/task-impl/src/components/KanbanCard.svelte
@@ -13,7 +13,7 @@
 // limitations under the License.
 -->
 <script lang="ts">
-  import ui, { ActionIcon, closePopup, showPopup, UserInfo } from '@anticrm/ui'
+  import ui, { ActionIcon, showPopup, UserInfo } from '@anticrm/ui'
   import type { Task } from '@anticrm/task'
   import task from '@anticrm/task'
   import MoreH from './icons/MoreH.svelte'
@@ -39,9 +39,7 @@
   }
 
   function select () {
-    showPopup(EditTask, { id: doc._id }, 'full', () => {
-      closePopup()
-    })
+    showPopup(EditTask, { id: doc._id }, 'full')
   }
 
   function isNew (card: Task, spaceLastViews: SpaceLastViews | undefined): boolean {

--- a/plugins/task-impl/src/components/TableView.svelte
+++ b/plugins/task-impl/src/components/TableView.svelte
@@ -19,7 +19,7 @@
   import task from '@anticrm/task'
   import type { Task } from '@anticrm/task'
   import { getClient } from '@anticrm/workbench'
-  import { Table, Label, UserInfo, DateTime, closePopup, showPopup } from '@anticrm/ui'
+  import { Table, Label, UserInfo, DateTime, showPopup } from '@anticrm/ui'
   import { deepEqual } from 'fast-equals'
   import EditTask from './EditTask.svelte'
   import TaskStatus from './TaskStatus.svelte'
@@ -79,13 +79,11 @@
   }
 
   function onClick (event: any) {
-    showPopup(EditTask, { id: event.detail._id }, 'full', () => {
-      closePopup()
-    })
+    showPopup(EditTask, { id: event.detail._id }, 'full')
   }
 
-  async function getUser (user: Ref<Account> | undefined): Promise<Account | undefined> {
-    if (user === undefined) return undefined
+  async function getUser (user: Ref<Account> | undefined | ''): Promise<Account | undefined> {
+    if (user === undefined || user === '') return undefined
     return (await client.findAll<Account>(core.class.Account, { _id: user })).pop()
   }
 </script>

--- a/plugins/task-impl/src/index.ts
+++ b/plugins/task-impl/src/index.ts
@@ -48,7 +48,7 @@ export default async (): Promise<TaskService> => {
   setResource(task.component.TaskRefView, TaskRef)
 
   setResource(task.handler.OpenHandler, async (objectClass, objectId) => {
-    await showPopup(task.component.EditTask, { id: objectId }, 'right')
+    await showPopup(task.component.EditTask, { id: objectId }, 'right').hide
   })
 
   return {}

--- a/plugins/workbench-impl/src/components/navigator/SpacesNav.svelte
+++ b/plugins/workbench-impl/src/components/navigator/SpacesNav.svelte
@@ -98,7 +98,7 @@
         label: model.addSpaceLabel,
         icon: IconAdd,
         action: async (ev?: Event): Promise<void> => {
-          return showPopup(create, {}, ev?.currentTarget as HTMLElement)
+          return showPopup(create, {}, ev?.currentTarget as HTMLElement).hide
         }
       })
     }
@@ -114,7 +114,7 @@
             label: model.label
           },
           'right'
-        )
+        ).hide
       }
     })
     return result
@@ -136,7 +136,7 @@
               space
             },
             'right' // ev?.currentTarget as HTMLElement
-          )
+          ).hide
         }
       })
     }


### PR DESCRIPTION
1. MDRefEditor now uses showPopup
2. Allow to control popups and obtain a real instance of component and allow to control it.
3.  Fix popups overlays dark only for first on
 

Preview mode:

<img width="700" alt="Screenshot 2021-11-13 at 22 17 28" src="https://user-images.githubusercontent.com/477235/141649177-279ec358-a1b5-469b-8710-b88417bf866a.png">


Editing mode: 
<img width="667" alt="Screenshot 2021-11-13 at 22 17 31" src="https://user-images.githubusercontent.com/477235/141649183-4c5d976b-58b8-401c-8d90-31784576c724.png">


Completion mode:
<img width="704" alt="Screenshot 2021-11-13 at 22 17 37" src="https://user-images.githubusercontent.com/477235/141649195-153b64b8-1806-4a21-8545-8ddd0d18e44c.png">


